### PR TITLE
Raise max_time decrement threshold to 800 in Game and Multiplay

### DIFF
--- a/src/Game.js
+++ b/src/Game.js
@@ -124,7 +124,7 @@ function next_question() {
     } else {
         btb_count++;
     }
-    if (max_time > 500) {
+    if (max_time > 800) {
         max_time -= 100;
     }
     start_time = Date.now()

--- a/src/Multiplay.js
+++ b/src/Multiplay.js
@@ -87,7 +87,7 @@ function next_question() {
     } else {
         btb_count++;
     }
-    if (max_time > 500) {
+    if (max_time > 800) {
         max_time -= 100;
     }
     start_time = Date.now()


### PR DESCRIPTION
### Motivation
- Prevent `max_time` from decreasing below a higher floor so the question timer does not shorten past 800ms too early.

### Description
- Change the `next_question()` decrement guard from `if (max_time > 500)` to `if (max_time > 800)` in `src/Multiplay.js` and `src/Game.js`.

### Testing
- No automated tests were run for this small, targeted logic change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ccb279e7748328932a12442a9f0fde)