### PR TITLE
Prevent correct-count increment after prior wrong tap in Game and Multiplay

### DIFF
--- a/src/Game.js
+++ b/src/Game.js
@@ -118,6 +118,7 @@ function next_question() {
     document.querySelector(".Japanese3").textContent = options[2];
     document.querySelector(".Japanese4").textContent = options[3];
     haptics.trigger(defaultPatterns.heavy);
+    currentQuestionHadMistake = false;
 
     if (Date.now() - start_time > max_time) {
         max_time = 1600;
@@ -155,6 +156,7 @@ let particles = [];
 let playingList = [];
 let startSoonReceived = false;
 let startGameReceived = false;
+let currentQuestionHadMistake = false;
 
 // ===== 割り込み追加 =====
 function addBlock(indexFromBottom) {
@@ -460,8 +462,10 @@ function Game() {
                 const selected_japanese = button.textContent;
                 const correct_japanese = question_list[q_num][1];
                 if (selected_japanese === correct_japanese) {
-                    incrementCorrectCount(question_list[q_num][0]);
-                    correct_answers++;
+                    if (!currentQuestionHadMistake) {
+                        incrementCorrectCount(question_list[q_num][0]);
+                        correct_answers++;
+                    }
                     document.querySelector(".answer").textContent = `${question_list[q_num][0]} = ${correct_japanese}`;
                     question_list.splice(q_num, 1);
                     document.querySelectorAll(".Japanese").forEach(button => {
@@ -475,6 +479,7 @@ function Game() {
                     }
                     next_question();
                 } else {
+                    currentQuestionHadMistake = true;
                     incrementWrongCount(question_list[q_num][0]);
                     button.style.backgroundColor = "lightgray";
                     button.style.boxShadow = "0 5px gray";

--- a/src/Multiplay.js
+++ b/src/Multiplay.js
@@ -81,6 +81,7 @@ function next_question() {
     document.querySelector(".Japanese3").textContent = options[2];
     document.querySelector(".Japanese4").textContent = options[3];
     haptics.trigger(defaultPatterns.heavy);
+    currentQuestionHadMistake = false;
 
     if (Date.now() - start_time > max_time) {
         max_time = 1600;
@@ -116,6 +117,7 @@ let particles = [];
 let playingList = [];
 let startSoonReceived = false;
 let startGameReceived = false;
+let currentQuestionHadMistake = false;
 
 // ===== 割り込み追加 =====
 function addBlock(indexFromBottom) {
@@ -408,8 +410,10 @@ function MultiPlay() {
                 const selected_japanese = button.textContent;
                 const correct_japanese = question_list[q_num][1];
                 if (selected_japanese === correct_japanese) {
-                    incrementCorrectCount(question_list[q_num][0]);
-                    correct_answers++;
+                    if (!currentQuestionHadMistake) {
+                        incrementCorrectCount(question_list[q_num][0]);
+                        correct_answers++;
+                    }
                     document.querySelector(".answer").textContent = `${question_list[q_num][0]} = ${correct_japanese}`;
                     question_list.splice(q_num, 1);
                     document.querySelectorAll(".Japanese").forEach(button => {
@@ -423,6 +427,7 @@ function MultiPlay() {
                     }
                     next_question();
                 } else {
+                    currentQuestionHadMistake = true;
                     incrementWrongCount(question_list[q_num][0]);
                     button.style.backgroundColor = "lightgray";
                     button.style.boxShadow = "0 5px gray";


### PR DESCRIPTION
### Motivation
- Users could tap a wrong option and then tap the correct option for the same question, which incorrectly incremented the stored correct count and in-game correct total.
- The change ensures a question is only counted as correct if it was not previously answered incorrectly during that round.

### Description
- Added a per-question flag `currentQuestionHadMistake` to both `src/Game.js` and `src/Multiplay.js` to track whether the current question has seen a wrong tap.
- Reset the flag in `next_question()` (immediately after showing options) so each new question starts with a clean state.
- Wrapped calls to `incrementCorrectCount(...)` and `correct_answers++` so they only run when `currentQuestionHadMistake` is `false`.
- Set `currentQuestionHadMistake = true` when a wrong option is tapped so subsequent correct taps on the same question do not increment counts.

### Testing
- Ran `npm test -- --watch=false` in the environment and the test run failed with `react-scripts: not found`, so automated test suite could not be executed here.
- Verified the changes by inspecting diffs and running code search to confirm the flag is declared, reset on new questions, set on wrong taps, and consulted the updated conditional around correct-count increments.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0a2c6ae508328a0cc5eb823e85b3e)