### PR TITLE
Reset game state on mount to prevent stale question totals

### DIFF
--- a/src/Game.js
+++ b/src/Game.js
@@ -156,6 +156,26 @@ let playingList = [];
 let startSoonReceived = false;
 let startGameReceived = false;
 
+function resetGameState() {
+    q_num = 0;
+    max_time = 1500;
+    start_time = Date.now();
+    question_list = [];
+    default_question_list = [];
+    number_of_questions = 0;
+    correct_answers = 0;
+    btb_count = 0;
+    btb_total = 0;
+    joined_count = 0;
+    joined_name = "";
+    beeped = false;
+    blocks = [];
+    particles = [];
+    playingList = [];
+    startSoonReceived = false;
+    startGameReceived = false;
+}
+
 // ===== 割り込み追加 =====
 function addBlock(indexFromBottom) {
     // 挿入
@@ -389,9 +409,7 @@ function Game() {
 
     useEffect(() => {
         setValue("");
-        q_num = 0;
-        btb_count = 0;
-        btb_total = 0; // BTB累計
+        resetGameState();
         mode = params.get("mode");
         if (mode === "together") {
             start_num = 1;

--- a/src/Multiplay.js
+++ b/src/Multiplay.js
@@ -117,6 +117,25 @@ let playingList = [];
 let startSoonReceived = false;
 let startGameReceived = false;
 
+function resetGameState() {
+    q_num = 0;
+    max_time = 1500;
+    start_time = Date.now();
+    question_list = [];
+    default_question_list = [];
+    number_of_questions = 0;
+    correct_answers = 0;
+    btb_count = 0;
+    btb_total = 0;
+    beeped = false;
+    blocks = [];
+    particles = [];
+    playingList = [];
+    startSoonReceived = false;
+    startGameReceived = false;
+    b_startTime = null;
+}
+
 // ===== 割り込み追加 =====
 function addBlock(indexFromBottom) {
     // 挿入
@@ -370,6 +389,7 @@ function MultiPlay() {
 
     useEffect(() => {
         setValue("");
+        resetGameState();
 
         ws = new WebSocket("wss://eitango-server.souki110212.workers.dev");
 


### PR DESCRIPTION
### Motivation
- Returning to the `Game` or `MultiPlay` screen after finishing a run kept previous session state (question totals, counters, blocks, BTB state), causing the displayed problem count to be incorrectly incremented.
- The change ensures a fresh runtime state when the components mount so a new playthrough starts cleanly.

### Description
- Added a `resetGameState()` helper in `src/Game.js` to clear module-level runtime variables such as `question_list`, `number_of_questions`, `correct_answers`, `blocks`, `particles`, BTB counters, and matchmaking flags.
- Added an equivalent `resetGameState()` helper in `src/Multiplay.js` (also resetting multiplayer animation state `b_startTime`).
- Called `resetGameState()` from the `useEffect` mount handler in both `Game` and `MultiPlay` so previous session data does not carry over when re-entering those screens.

### Testing
- Attempted `npm run build` in the project root, but the build failed in this environment due to missing `react-scripts` (`sh: 1: react-scripts: not found`).
- No other automated tests were executed in this environment; changes were compiled locally via source edits and committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0a3bd22f083289518277df582f96d)