### PR TITLE
範囲選択の正答率計算で未プレイ単語を0%として反映

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -54,19 +54,22 @@ function Select() {
     const getRangeAccuracy = (start, end) => {
         if (words.length === 0) return null;
         if (isNaN(start) || isNaN(end)) return null;
-        let totalCorrect = 0;
-        let totalWrong = 0;
+        let accuracySum = 0;
+        let wordCount = 0;
         const s = Math.max(1, start);
         const e = Math.min(words.length, end);
         for (let i = s - 1; i < e; i++) {
             if (!words[i]) continue;
             const word = words[i][0];
-            totalCorrect += stats.correctCounts[word] || 0;
-            totalWrong += stats.wrongCounts[word] || 0;
+            const correctCount = stats.correctCounts[word] || 0;
+            const wrongCount = stats.wrongCounts[word] || 0;
+            const totalCount = correctCount + wrongCount;
+            const wordAccuracy = totalCount === 0 ? 0 : correctCount / totalCount;
+            accuracySum += wordAccuracy;
+            wordCount += 1;
         }
-        const total = totalCorrect + totalWrong;
-        if (total === 0) return null;
-        return ((totalCorrect / total) * 100).toFixed(1);
+        if (wordCount === 0) return null;
+        return ((accuracySum / wordCount) * 100).toFixed(1);
     };
 
     // 1~1800まで100区切りでボタンを生成


### PR DESCRIPTION
### Motivation
- 範囲選択画面の表示で、未プレイの単語を0%として正答率に反映するために計算方法を変更する必要がありました。

### Description
- `src/Select.js` の `getRangeAccuracy` を修正して、範囲内の各単語ごとの正答率を算出して平均を返す方式に変更しました。
- 各単語は `correctCount` と `wrongCount` を取得し、`totalCount === 0 ? 0 : correctCount / totalCount` で `wordAccuracy` を決定します。
- 範囲全体の正答率は単語ごとの `wordAccuracy` の平均を取り `((accuracySum / wordCount) * 100).toFixed(1)` で割合表示します。

### Testing
- 実装ファイルの変更は動作ロジックの単体修正に限定されましたが、`npm run build` は環境に `react-scripts` が存在しないため失敗しました（`react-scripts: not found`）。
- `npm ci` は `package.json` と `package-lock.json` の不整合により失敗し、`Missing: yaml@2.8.3 from lock file` が原因でした。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d309dc14f483289c73e6a4524065bd)