### PR TITLE
Read question words aloud in single and multiplayer modes

### DIFF
--- a/src/Game.js
+++ b/src/Game.js
@@ -151,8 +151,20 @@ function buildQuestionList() {
     return eitango.slice(start_num - 1, end_num);
 }
 
+
+function speakQuestionWord(word) {
+    if (!word || typeof window === "undefined" || !window.speechSynthesis) return;
+    window.speechSynthesis.cancel();
+    const utterance = new SpeechSynthesisUtterance(word);
+    utterance.lang = "en-US";
+    utterance.rate = 0.9;
+    utterance.pitch = 1;
+    window.speechSynthesis.speak(utterance);
+}
+
 function next_question() {
     document.querySelector(".English").textContent = question_list[q_num][0];
+    speakQuestionWord(question_list[q_num][0]);
     const correct_japanese = question_list[q_num][1];
     const options = [correct_japanese];
     while (options.length < 4) {

--- a/src/Multiplay.js
+++ b/src/Multiplay.js
@@ -67,8 +67,20 @@ function StartGame() {
     update();
 }
 
+
+function speakQuestionWord(word) {
+    if (!word || typeof window === "undefined" || !window.speechSynthesis) return;
+    window.speechSynthesis.cancel();
+    const utterance = new SpeechSynthesisUtterance(word);
+    utterance.lang = "en-US";
+    utterance.rate = 0.9;
+    utterance.pitch = 1;
+    window.speechSynthesis.speak(utterance);
+}
+
 function next_question() {
     document.querySelector(".English").textContent = question_list[q_num][0];
+    speakQuestionWord(question_list[q_num][0]);
     const correct_japanese = question_list[q_num][1];
     const options = [correct_japanese];
     while (options.length < 4) {


### PR DESCRIPTION
### Motivation
- Make each presented English prompt be spoken aloud in both single-player and multiplayer flows to improve accessibility and spoken practice.

### Description
- Add a `speakQuestionWord` helper (uses `SpeechSynthesisUtterance` with `lang: "en-US"`, `rate: 0.9`, `pitch: 1`) to `src/Game.js` and `src/Multiplay.js`.
- Invoke `speakQuestionWord(question_list[q_num][0])` from `next_question()` so the English word is spoken immediately after it is displayed.

### Testing
- Ran `npm run build`, which failed in this environment with `react-scripts: not found`, so automated build could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5ce1015e88328a36da382b56f3d75)