### PR TITLE
ミス統計画面の並び順を正解率昇順に変更

### DIFF
--- a/src/MistakeStats.js
+++ b/src/MistakeStats.js
@@ -43,11 +43,17 @@ function MistakeStats() {
         });
 
         return mapped.sort((a, b) => {
+            const aHasAnswered = a.correctCount + a.wrongCount > 0;
+            const bHasAnswered = b.correctCount + b.wrongCount > 0;
+
+            if (aHasAnswered !== bHasAnswered) {
+                return aHasAnswered ? -1 : 1;
+            }
+            if (a.accuracy !== b.accuracy) {
+                return a.accuracy - b.accuracy;
+            }
             if (b.wrongCount !== a.wrongCount) {
                 return b.wrongCount - a.wrongCount;
-            }
-            if (b.correctCount !== a.correctCount) {
-                return b.correctCount - a.correctCount;
             }
             return a.no - b.no;
         });


### PR DESCRIPTION
### Motivation
- ミス統計画面で正解率が低い単語を優先的に確認できるように、一覧の並び順を変更するための修正です。
- 回答履歴のない（正解数+ミス数が0）単語は優先度を下げて後ろに表示することで、実際に学習が必要な単語を目立たせます。

### Description
- 並び替えロジックを `src/MistakeStats.js` の `useMemo` 内で調整し、回答履歴の有無を先に判定するようにしました.
- 具体的にはまず `a.correctCount + a.wrongCount > 0` を使って回答のある項目を前にし、次に `accuracy` を昇順（低い順）で比較するようにしました.
- `accuracy` が同率の場合は `wrongCount` を多い方を先にし、最終的に元のインデックス（`no`）で安定ソートするようにしました.
- 変更は `src/MistakeStats.js` のソート関数（`mapped.sort(...)`）に対する置換のみです.

### Testing
- `npm run build` を実行しましたが、環境に `react-scripts` がインストールされていないためビルドは失敗しました（`react-scripts: not found`）。
- 以上以外の自動テストは実行しておらず、ユニットテストやブラウザでの表示確認は未実施です。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9d091ac7c8328aacd4b279b2721c7)