### PR TITLE
Add support for playing both eitango and sokutan datasets

### DIFF
--- a/src/Game.js
+++ b/src/Game.js
@@ -20,6 +20,7 @@ let q_num = 0;
 let start_num = 1;
 let end_num = 1800;
 let priority_mode;
+let dataset = "eitango";
 let eitango;
 let navigate;
 let selected_question_count = 0;
@@ -479,13 +480,14 @@ function Game() {
     navigate = useNavigate();
     const location = useLocation();
     const params = new URLSearchParams(location.search);
+    const datasetLabel = params.get("dataset") === "sokutan" ? "速単" : "英単語";
     const readyTitleText = params.get("mode") === "together"
-        ? "ランダム"
+        ? `${datasetLabel} / ランダム`
         : (params.get("priority") === "leastPlayed50"
-            ? "プレイ回数が少ない順"
+            ? `${datasetLabel} / プレイ回数が少ない順`
             : (params.get("priority") === "lowAccuracy50"
-                ? "正答率が低い順"
-                : `${parseInt(params.get("start")) || 1} ~ ${parseInt(params.get("end")) || 1800}`));
+                ? `${datasetLabel} / 正答率が低い順`
+                : `${datasetLabel} / ${parseInt(params.get("start")) || 1} ~ ${parseInt(params.get("end")) || 1800}`));
 
     function logout() {
         localStorage.removeItem("user_name");
@@ -497,10 +499,12 @@ function Game() {
         resetGameState();
         mode = params.get("mode");
         priority_mode = params.get("priority") || "";
+        dataset = params.get("dataset") === "sokutan" ? "sokutan" : "eitango";
         start_num = parseInt(params.get("start")) || 1;
         end_num = parseInt(params.get("end")) || 1800;
 
         if (mode === "together") {
+            dataset = "eitango";
             start_num = 1;
             end_num = 1800;
             document.querySelector(".dialog").showModal();
@@ -532,13 +536,16 @@ function Game() {
             }
         }
 
-        fetch('/eitango.json')
+        fetch(dataset === "sokutan" ? "/sokutan.json" : "/eitango.json")
             .then(res => res.json())
             .then(data => {
                 eitango = data;
                 console.log(eitango);
+                if (end_num > eitango.length) {
+                    end_num = eitango.length;
+                }
             })
-            .catch(err => console.error('eitango.jsonの読み込みに失敗しました', err));
+            .catch(err => console.error(`${dataset}.jsonの読み込みに失敗しました`, err));
 
         bar_canvas = document.getElementById("bar");
         b_ctx = bar_canvas.getContext("2d");

--- a/src/Select.js
+++ b/src/Select.js
@@ -10,10 +10,10 @@ const slideVariants = {
     exit: { x: "-100%", opacity: 0 },
 };
 
-function SelectButton({ start, end, mode, accuracy }) {
+function SelectButton({ start, end, mode, dataset, accuracy }) {
     const navigate = useNavigate();
     return (
-        <button className="SelectButton" onClick={() => navigate(`/game?mode=${mode}&start=${start}&end=${end}`)}>
+        <button className="SelectButton" onClick={() => navigate(`/game?mode=${mode}&dataset=${dataset}&start=${start}&end=${end}`)}>
             <div className="rangeText">{start} ~ {end}</div>
             {accuracy !== null && <div className="accuracy">{accuracy}%</div>}
         </button>
@@ -25,14 +25,15 @@ function Select() {
     const navigate = useNavigate();
     const [customStart, setCustomStart] = useState(localStorage.getItem("customStart") || "");
     const [customEnd, setCustomEnd] = useState(localStorage.getItem("customEnd") || "");
+    const [dataset, setDataset] = useState(localStorage.getItem("dataset") || "eitango");
     const [words, setWords] = useState([]);
 
     useEffect(() => {
-        fetch("/eitango.json")
+        fetch(dataset === "sokutan" ? "/sokutan.json" : "/eitango.json")
             .then(res => res.json())
             .then(data => setWords(data))
             .catch(err => console.error(err));
-    }, []);
+    }, [dataset]);
 
     useEffect(() => {
         localStorage.setItem("customStart", customStart);
@@ -41,6 +42,10 @@ function Select() {
     useEffect(() => {
         localStorage.setItem("customEnd", customEnd);
     }, [customEnd]);
+
+    useEffect(() => {
+        localStorage.setItem("dataset", dataset);
+    }, [dataset]);
 
     const params = new URLSearchParams(location.search);
     const mode = params.get("mode") || "alone";
@@ -72,27 +77,28 @@ function Select() {
         return ((accuracySum / wordCount) * 100).toFixed(1);
     };
 
-    // 1~1800まで100区切りでボタンを生成
+    // データ数に応じて100区切りでボタンを生成
     const buttons = [];
-    for (let i = 0; i < 18; i++) {
+    const totalRanges = Math.ceil(words.length / 100);
+    for (let i = 0; i < totalRanges; i++) {
         const start = i * 100 + 1;
-        const end = (i + 1) * 100;
+        const end = Math.min((i + 1) * 100, words.length);
         const accuracy = getRangeAccuracy(start, end);
-        buttons.push(<SelectButton key={i} start={start} end={end} mode={mode} accuracy={accuracy} />);
+        buttons.push(<SelectButton key={i} start={start} end={end} mode={mode} dataset={dataset} accuracy={accuracy} />);
     }
 
     const handleCustomStart = () => {
         const start = parseInt(customStart);
         const end = parseInt(customEnd);
-        if (!isNaN(start) && !isNaN(end) && start > 0 && end >= start) {
-            navigate(`/game?mode=${mode}&start=${start}&end=${end}`);
+        if (!isNaN(start) && !isNaN(end) && start > 0 && end >= start && end <= words.length) {
+            navigate(`/game?mode=${mode}&dataset=${dataset}&start=${start}&end=${end}`);
         } else {
             alert("正しい範囲を入力してください");
         }
     };
 
     const navigatePriorityMode = (priorityMode) => {
-        navigate(`/game?mode=${mode}&priority=${priorityMode}`);
+        navigate(`/game?mode=${mode}&dataset=${dataset}&priority=${priorityMode}`);
     };
 
     const customAccuracy = getRangeAccuracy(parseInt(customStart), parseInt(customEnd));
@@ -108,6 +114,22 @@ function Select() {
             <Link to="/mode" className="back">&lt; もどる</Link>
             <h1>範囲を選択</h1>
             <p>{mode === "alone" ? "ひとりで" : "みんなで"}</p>
+            <div className="priorityModes">
+                <button
+                    className="priorityModeButton"
+                    onClick={() => setDataset("eitango")}
+                    style={{ opacity: dataset === "eitango" ? 1 : 0.6 }}
+                >
+                    英単語
+                </button>
+                <button
+                    className="priorityModeButton"
+                    onClick={() => setDataset("sokutan")}
+                    style={{ opacity: dataset === "sokutan" ? 1 : 0.6 }}
+                >
+                    速単
+                </button>
+            </div>
 
             <div className="buttonContainer">
                 {mode === "alone" && (


### PR DESCRIPTION
### Motivation
- ゲームを `public/eitango.json` だけでなく `public/sokutan.json` のデータでも遊べるようにするための対応。
- 範囲選択画面でデータセットを切り替えられるようにして、選択中のデータ長に応じて範囲ボタン/バリデーションを調整するため。

### Description
- `src/Select.js`: データセット選択 UI を追加し、選択を `localStorage` に保持するようにしたことと、選択に応じて `eitango.json` / `sokutan.json` を読み込むようにしたことを実装した。`dataset` クエリを `Game` へ渡すようにしている。（`SelectButton` に `dataset` 引数を追加）
- `src/Select.js`: 範囲ボタンの生成を固定の `1~1800` から読み込んだデータ長に基づく 100 区切りに変更し、カスタム範囲の入力時にデータ長を超えないバリデーションを追加した。
- `src/Game.js`: クエリパラメータの `dataset` を解釈して `fetch` で `eitango.json` / `sokutan.json` を切り替え読み込みするように変更し、Ready 表示にデータセット名を付与するようにした。マルチプレイ（`mode=together`）時は従来どおり `eitango` を強制する挙動を維持している。読み込み後に `end_num` をデータ件数でクランプして範囲外アクセスを防いでいる。
- `Multiplay.js` は変更していない（リクエストどおり）。

### Testing
- アプリケーションのビルドを試行するために `npm run build` を実行したが、実行環境に `react-scripts` が存在しないためビルドは失敗した（`react-scripts: not found`）。
- ソース差分と動作フローはローカルファイルの差分確認で確認済み（`src/Select.js`, `src/Game.js` が更新）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcd04b9ed08328850434413699113e)