### PR TITLE
Skip wrongCountStorage calls in Game when dict=1

### DIFF
--- a/src/Game.js
+++ b/src/Game.js
@@ -23,6 +23,7 @@ let priority_mode;
 let eitango;
 let navigate;
 let selected_question_count = 0;
+let isDictMode = false;
 
 // setInterval, requestAnimationFrameのID管理用
 let intervalIds = [];
@@ -111,6 +112,9 @@ function StartGame() {
 
 function buildQuestionList() {
     if (!Array.isArray(eitango) || eitango.length === 0) return [];
+    if (isDictMode) {
+        return eitango.slice(start_num - 1, end_num);
+    }
     if (priority_mode === "leastPlayed50") {
         const correctCounts = getCorrectCounts();
         const wrongCounts = getWrongCounts();
@@ -496,6 +500,7 @@ function Game() {
     useEffect(() => {
         resetGameState();
         mode = params.get("mode");
+        isDictMode = params.get("dict") === "1";
         priority_mode = params.get("priority") || "";
         start_num = parseInt(params.get("start")) || 1;
         end_num = parseInt(params.get("end")) || 1800;
@@ -568,7 +573,9 @@ function Game() {
                 const correct_japanese = question_list[q_num][1];
                 if (selected_japanese === correct_japanese) {
                     if (!currentQuestionHadMistake) {
-                        incrementCorrectCount(question_list[q_num][0]);
+                        if (!isDictMode) {
+                            incrementCorrectCount(question_list[q_num][0]);
+                        }
                         correct_answers++;
                     }
                     document.querySelector(".answer").textContent = `${question_list[q_num][0]} = ${correct_japanese}`;
@@ -585,7 +592,9 @@ function Game() {
                     next_question();
                 } else {
                     currentQuestionHadMistake = true;
-                    incrementWrongCount(question_list[q_num][0]);
+                    if (!isDictMode) {
+                        incrementWrongCount(question_list[q_num][0]);
+                    }
                     wrong_answers++;
                     button.style.backgroundColor = "lightgray";
                     button.style.boxShadow = "0 5px gray";


### PR DESCRIPTION
### Motivation
- Dictionary mode (`dict=1`) should not read from or mutate persisted correct/wrong counts so playing in dictionary mode does not affect learning statistics or priority-based selection.

### Description
- Added an `isDictMode` flag in `src/Game.js` that is set from the `dict` query parameter (`isDictMode = params.get("dict") === "1"`).
- Updated `buildQuestionList` to return a plain slice `eitango.slice(start_num - 1, end_num)` when `isDictMode` is true to avoid calling `getCorrectCounts`/`getWrongCounts`.
- Wrapped calls to `incrementCorrectCount` and `incrementWrongCount` with `if (!isDictMode) { ... }` so these functions are not executed in dictionary mode.
- All changes are limited to `src/Game.js`; `Multiplay.js` was not modified.

### Testing
- Ran `npm run build` which failed in this environment due to `react-scripts` not being available (build could not be completed).
- Ran `npm ci` which failed because `package-lock.json` and `package.json` are out of sync, so dependencies could not be installed.
- Code changes were saved and committed locally; no further automated test suite was executed due to the environment failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dec433f560832895222fbac01efcc5)