### PR TITLE
Fix missing `dict` parameter when navigating to /game

### DIFF
--- a/src/Game.js
+++ b/src/Game.js
@@ -16,6 +16,7 @@ const haptics = new WebHaptics();
 
 
 let mode;
+let dict;
 let q_num = 0;
 let start_num = 1;
 let end_num = 1800;
@@ -496,6 +497,7 @@ function Game() {
     useEffect(() => {
         resetGameState();
         mode = params.get("mode");
+        dict = params.get("dict") || "eitango";
         priority_mode = params.get("priority") || "";
         start_num = parseInt(params.get("start")) || 1;
         end_num = parseInt(params.get("end")) || 1800;
@@ -532,13 +534,13 @@ function Game() {
             }
         }
 
-        fetch('/eitango.json')
+        fetch(`/${dict}.json`)
             .then(res => res.json())
             .then(data => {
                 eitango = data;
                 console.log(eitango);
             })
-            .catch(err => console.error('eitango.jsonの読み込みに失敗しました', err));
+            .catch(err => console.error(`${dict}.jsonの読み込みに失敗しました`, err));
 
         bar_canvas = document.getElementById("bar");
         b_ctx = bar_canvas.getContext("2d");

--- a/src/Mode.js
+++ b/src/Mode.js
@@ -10,6 +10,7 @@ const slideVariants = {
 
 function Mode() {
     const navigate = useNavigate();
+    const dict = "eitango";
     return (
         <motion.div
             variants={slideVariants}
@@ -25,8 +26,8 @@ function Mode() {
                 <span>現在のスケジュール(<span class="date">15:00 ~ 17:00</span>)</span>
                 <div class="range">東進英単語1800 1~50</div>
             </div>
-            <button onClick={() => navigate("/select?mode=alone")}>ひとりで</button>
-            <button onClick={() => navigate("/game?mode=together")}>みんなで</button>
+            <button onClick={() => navigate(`/select?dict=${dict}&mode=alone`)}>ひとりで</button>
+            <button onClick={() => navigate(`/game?dict=${dict}&mode=together`)}>みんなで</button>
             <button onClick={() => navigate("/mistakes")}>問題一覧を見る</button>
         </motion.div>);
 }

--- a/src/Select.js
+++ b/src/Select.js
@@ -10,10 +10,11 @@ const slideVariants = {
     exit: { x: "-100%", opacity: 0 },
 };
 
-function SelectButton({ start, end, mode, accuracy }) {
+function SelectButton({ start, end, mode, dict, accuracy }) {
     const navigate = useNavigate();
+    const buildGamePath = () => `/game?dict=${dict}&mode=${mode}&start=${start}&end=${end}`;
     return (
-        <button className="SelectButton" onClick={() => navigate(`/game?mode=${mode}&start=${start}&end=${end}`)}>
+        <button className="SelectButton" onClick={() => navigate(buildGamePath())}>
             <div className="rangeText">{start} ~ {end}</div>
             {accuracy !== null && <div className="accuracy">{accuracy}%</div>}
         </button>
@@ -44,6 +45,7 @@ function Select() {
 
     const params = new URLSearchParams(location.search);
     const mode = params.get("mode") || "alone";
+    const dict = params.get("dict") || "eitango";
 
     const stats = useMemo(() => {
         const correctCounts = getCorrectCounts();
@@ -78,21 +80,21 @@ function Select() {
         const start = i * 100 + 1;
         const end = (i + 1) * 100;
         const accuracy = getRangeAccuracy(start, end);
-        buttons.push(<SelectButton key={i} start={start} end={end} mode={mode} accuracy={accuracy} />);
+        buttons.push(<SelectButton key={i} start={start} end={end} mode={mode} dict={dict} accuracy={accuracy} />);
     }
 
     const handleCustomStart = () => {
         const start = parseInt(customStart);
         const end = parseInt(customEnd);
         if (!isNaN(start) && !isNaN(end) && start > 0 && end >= start) {
-            navigate(`/game?mode=${mode}&start=${start}&end=${end}`);
+            navigate(`/game?dict=${dict}&mode=${mode}&start=${start}&end=${end}`);
         } else {
             alert("正しい範囲を入力してください");
         }
     };
 
     const navigatePriorityMode = (priorityMode) => {
-        navigate(`/game?mode=${mode}&priority=${priorityMode}`);
+        navigate(`/game?dict=${dict}&mode=${mode}&priority=${priorityMode}`);
     };
 
     const customAccuracy = getRangeAccuracy(parseInt(customStart), parseInt(customEnd));


### PR DESCRIPTION
### Motivation
- Navigations from the Select/Mode pages sometimes omitted the `dict` query parameter, causing the Game page to load the wrong dictionary or fall back unexpectedly.
- The intent is to make all navigation paths to `/game` carry the selected dictionary identifier so `Game` can load the correct JSON file.
- This prevents inconsistent behavior when users choose ranges, custom ranges, or priority modes that expect a specific dictionary.

### Description
- `Select`: added `dict` extraction from `location.search`, passed `dict` to `SelectButton`, and switched button/custom/priority navigation to include `dict` in the `/game` query string; added `buildGamePath` helper for button links.
- `Mode`: added a `dict = "eitango"` constant and updated navigation to include `dict` when routing to `/select` (alone) and `/game` (together).
- `Game`: added a top-level `dict` variable, read `dict` from query params with fallback to `eitango`, and changed the fetch to load `/${dict}.json` and to log an error referencing the dynamic file name.
- Small adjustments to component props and navigation calls to ensure the `dict` parameter is consistently preserved across flows.

### Testing
- Ran `npm run build` and the project built successfully producing an optimized production bundle.
- The build completed with existing ESLint warnings that are unrelated to this change, and there were no build errors caused by the modifications.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e58c530ed88328ad637c522bc63f2b)