### PR TITLE
Fix public asset and JSON loading when hosted under /tango1800

### DIFF
--- a/src/Game.js
+++ b/src/Game.js
@@ -276,7 +276,7 @@ function addBlock(indexFromBottom) {
 function breakBlock() {
 
     // break.mp3を再生
-    const audio = new Audio('/break.mp3');
+    const audio = new Audio(`${process.env.PUBLIC_URL}/break.mp3`);
     audio.play();
 
     if (blocks.length === 0) return;
@@ -364,7 +364,7 @@ function update() {
     b_ctx.clearRect(0, 0, 1000, 50);
     if (Date.now() - start_time > max_time) {
         if (!beeped) {
-            const audio = new Audio('/beep.mp3');
+            const audio = new Audio(`${process.env.PUBLIC_URL}/beep.mp3`);
             audio.play();
             // 失敗時、カウント中のbtb_countを累計に加算
             btb_total += btb_count;
@@ -539,7 +539,7 @@ function Game() {
                 });
             }
         }
-        const json_file = ["/eitango.json", "/sokutan.json"]
+        const json_file = [`${process.env.PUBLIC_URL}/eitango.json`, `${process.env.PUBLIC_URL}/sokutan.json`]
         fetch(json_file[dict])
             .then(res => res.json())
             .then(data => {
@@ -615,7 +615,7 @@ function Game() {
                         addBlock(randomNum);
                         question_list.splice(randomNum, 0, question_list[q_num]);
                     }
-                    const audio = new Audio('/wrong.mp3');
+                    const audio = new Audio(`${process.env.PUBLIC_URL}/wrong.mp3`);
                     audio.play();
                     number_of_questions += 2;
                 }

--- a/src/MistakeStats.js
+++ b/src/MistakeStats.js
@@ -15,7 +15,7 @@ function MistakeStats() {
     const [error, setError] = useState("");
 
     useEffect(() => {
-        fetch("/eitango.json")
+        fetch(`${process.env.PUBLIC_URL}/eitango.json`)
             .then((res) => res.json())
             .then((data) => setWords(Array.isArray(data) ? data : []))
             .catch(() => setError("データの読み込みに失敗しました。"));

--- a/src/Multiplay.js
+++ b/src/Multiplay.js
@@ -188,7 +188,7 @@ function addBlock(indexFromBottom) {
 function breakBlock() {
 
     // break.mp3を再生
-    const audio = new Audio('/break.mp3');
+    const audio = new Audio(`${process.env.PUBLIC_URL}/break.mp3`);
     audio.play();
 
     if (blocks.length === 0) return;
@@ -278,7 +278,7 @@ function update() {
         if (!beeped) {
             let enemy = playingList.filter(i => i !== localStorage.getItem("user_name"))[Math.floor(Math.random() * (playingList.length - 1))];
             sendMessage({ type: "btb", count: btb_count, user_name: localStorage.getItem("user_name"), enemy });
-            const audio = new Audio('/beep.mp3');
+            const audio = new Audio(`${process.env.PUBLIC_URL}/beep.mp3`);
             audio.play().catch(e => { /* 失敗しても無視 */ });
             // 失敗時、カウント中のbtb_countを累計に加算
             btb_total += btb_count;
@@ -325,7 +325,7 @@ function onMessage(event) {
     if (data.type === "btb") {
         if (data.enemy === localStorage.getItem("user_name") && data.count > 0) {
             setTimeout(() => {
-                const audio = new Audio('/damage.mp3');
+                const audio = new Audio(`${process.env.PUBLIC_URL}/damage.mp3`);
                 audio.play().catch(e => { /* 失敗しても無視 */ });
             }, 1200);
             for (var i = 0; i < data.count; i++) {
@@ -445,7 +445,7 @@ function MultiPlay() {
 
         ws = new WebSocket("wss://eitango-server.souki110212.workers.dev");
 
-        fetch('/eitango.json')
+        fetch(`${process.env.PUBLIC_URL}/eitango.json`)
             .then(res => res.json())
             .then(data => {
                 eitango = data;
@@ -514,7 +514,7 @@ function MultiPlay() {
                         addBlock(randomNum);
                         question_list.splice(randomNum, 0, question_list[q_num]);
                     }
-                    const audio = new Audio('/wrong.mp3');
+                    const audio = new Audio(`${process.env.PUBLIC_URL}/wrong.mp3`);
                     audio.play();
                     number_of_questions += 2;
                 }

--- a/src/Select.js
+++ b/src/Select.js
@@ -30,7 +30,7 @@ function Select() {
     const [tab, setTab] = useState(0);
 
     useEffect(() => {
-        fetch("/eitango.json")
+        fetch(`${process.env.PUBLIC_URL}/eitango.json`)
             .then(res => res.json())
             .then(data => setWords(data))
             .catch(err => console.error(err));


### PR DESCRIPTION
### Motivation
- Root-relative URLs (e.g. `/eitango.json`, `/break.mp3`) failed to resolve when the app is served under the `/tango1800` basename, causing assets and dictionary JSON to not load.

### Description
- Replaced root-relative static/audio references with `process.env.PUBLIC_URL` (e.g. `new Audio(`${process.env.PUBLIC_URL}/break.mp3`)`) in `src/Game.js` and `src/Multiplay.js` so audio resolves under a subpath.
- Switched JSON `fetch` calls to use `process.env.PUBLIC_URL` (e.g. `fetch(`${process.env.PUBLIC_URL}/eitango.json`)`) in `src/Game.js`, `src/Multiplay.js`, `src/Select.js`, and `src/MistakeStats.js` so dictionary files load correctly when deployed to `/tango1800`.
- Kept existing behavior unchanged aside from path resolution and updated only the minimal call sites that used root-relative paths.

### Testing
- Ran `npm run build` and the production build completed successfully with the app built assuming the `/tango1800/` homepage path.
- The build emitted ESLint warnings that were pre-existing and unrelated to the path changes, and no new build errors were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e74d3dec50832891b0f3d5bc745b09)