### PR TITLE
Enable offline access with a service worker

### DIFF
--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,0 +1,76 @@
+const CACHE_VERSION = 'tango1800-v1';
+const STATIC_CACHE = `static-${CACHE_VERSION}`;
+const RUNTIME_CACHE = `runtime-${CACHE_VERSION}`;
+
+const CORE_ASSETS = [
+  '/',
+  '/index.html',
+  '/manifest.json',
+  '/favicon.ico',
+  '/logo192.png',
+  '/logo512.png',
+  '/eitango.json',
+  '/sokutan.json',
+  '/beep.mp3',
+  '/break.mp3',
+  '/wrong.mp3',
+  '/damage.mp3',
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(STATIC_CACHE).then((cache) => cache.addAll(CORE_ASSETS))
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(
+        keys
+          .filter((key) => ![STATIC_CACHE, RUNTIME_CACHE].includes(key))
+          .map((key) => caches.delete(key))
+      )
+    )
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') {
+    return;
+  }
+
+  const requestUrl = new URL(event.request.url);
+  const isSameOrigin = requestUrl.origin === self.location.origin;
+
+  if (event.request.mode === 'navigate') {
+    event.respondWith(
+      fetch(event.request).catch(() => caches.match('/index.html'))
+    );
+    return;
+  }
+
+  if (!isSameOrigin) {
+    return;
+  }
+
+  event.respondWith(
+    caches.match(event.request).then((cachedResponse) => {
+      if (cachedResponse) {
+        return cachedResponse;
+      }
+
+      return fetch(event.request)
+        .then((networkResponse) => {
+          if (networkResponse && networkResponse.status === 200) {
+            const cloned = networkResponse.clone();
+            caches.open(RUNTIME_CACHE).then((cache) => cache.put(event.request, cloned));
+          }
+          return networkResponse;
+        })
+        .catch(() => caches.match('/index.html'));
+    })
+  );
+});

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,16 @@ root.render(
   <App />
 );
 
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker
+      .register(`${process.env.PUBLIC_URL}/service-worker.js`)
+      .catch((error) => {
+        console.error('Service Worker registration failed:', error);
+      });
+  });
+}
+
 // If you want to start measuring performance in your app, pass a function
 // to log results (for example: reportWebVitals(console.log))
 // or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals


### PR DESCRIPTION
### Motivation
- Provide offline access for the app shell and gameplay assets so the app can function when network connectivity is absent.
- Reduce runtime network dependency by pre-caching dictionary JSON and audio files used during gameplay.
- Ensure the service worker is registered on page load so caching behavior is activated for end users.

### Description
- Add `public/service-worker.js` which pre-caches core assets (including `/index.html`, `/eitango.json`, `/sokutan.json`, and audio files) and implements runtime caching for same-origin `GET` requests.
- Implement navigation fallback to `index.html` for offline route handling within the service worker.
- Register the service worker in `src/index.js` by calling `navigator.serviceWorker.register` on `window.load`.

### Testing
- Ran `npm run build` which completed successfully and produced the optimized production build.
- Build completed with unrelated ESLint warnings that were present before this change and did not cause the build to fail.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaa3b6621083288ea5e327d92ac9d0)