### PR TITLE
オフライン時に「みんなで」モードを無効化

### DIFF
--- a/src/Game.js
+++ b/src/Game.js
@@ -509,6 +509,11 @@ function Game() {
         end_num = parseInt(params.get("end")) || 1800;
 
         if (mode === "together") {
+            if (!navigator.onLine) {
+                alert("オフライン中は『みんなで』モードを利用できません");
+                navigate("/mode");
+                return;
+            }
             start_num = 1;
             end_num = 1800;
             document.querySelector(".dialog").showModal();

--- a/src/Mode.js
+++ b/src/Mode.js
@@ -1,5 +1,6 @@
 import { motion } from "framer-motion";
 import { Link, useNavigate } from "react-router-dom";
+import { useEffect, useState } from "react";
 import './Mode.css';
 
 const slideVariants = {
@@ -10,6 +11,21 @@ const slideVariants = {
 
 function Mode() {
     const navigate = useNavigate();
+    const [isOnline, setIsOnline] = useState(navigator.onLine);
+
+    useEffect(() => {
+        const handleOnline = () => setIsOnline(true);
+        const handleOffline = () => setIsOnline(false);
+
+        window.addEventListener("online", handleOnline);
+        window.addEventListener("offline", handleOffline);
+
+        return () => {
+            window.removeEventListener("online", handleOnline);
+            window.removeEventListener("offline", handleOffline);
+        };
+    }, []);
+
     return (
         <motion.div
             variants={slideVariants}
@@ -22,7 +38,13 @@ function Mode() {
             <Link to="/" className="back">&lt; もどる</Link>
             <h1 className="title">モード選択</h1>
             <button onClick={() => navigate("/select?mode=alone")}>ひとりで</button>
-            <button onClick={() => navigate("/game?mode=together")}>みんなで</button>
+            <button
+                onClick={() => navigate("/game?mode=together")}
+                disabled={!isOnline}
+                title={!isOnline ? "オフライン時は利用できません" : ""}
+            >
+                みんなで{!isOnline ? " (オフライン時は利用不可)" : ""}
+            </button>
             <button onClick={() => navigate("/mistakes")}>問題一覧を見る</button>
             <div class="schedule">
                 <span>現在のスケジュール(<span class="date">15:00 ~ 17:00</span>)</span>


### PR DESCRIPTION
### Motivation
- オフライン環境で `みんなで` モードに入ろうとするとサーバ接続やログインが必要になるため、ユーザーが選べないようにして誤操作を防ぐ意図です。

### Description
- `src/Mode.js` にて `navigator.onLine` を初期値にした状態管理と `online`/`offline` イベントリスナーを追加して接続状態を監視するようにしました。
- モード選択画面の `みんなで` ボタンをオフライン時に `disabled` にし、ツールチップとラベルで利用不可であることを表示するようにしました（変更箇所: `src/Mode.js`）。
- 直接 `?mode=together` に遷移された場合の保険として `src/Game.js` に `navigator.onLine` チェックを追加し、オフラインなら `alert` を出して `/mode` にリダイレクトするガードを導入しました。

### Testing
- ビルドを実行して `npm run build` が成功することを確認しました（最適化ビルド完了）。
- ビルド時に既存の ESLint 警告が表示されましたが、今回の変更によるビルド失敗は発生していません。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eab538d1a48328ac706cf95f749cfb)