### PR TITLE
Fix priority mode URL parameter for dictionary selection

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -101,7 +101,7 @@ function Select() {
     };
 
     const navigatePriorityMode = (priorityMode, tab) => {
-        navigate(`/game?mode=${mode}&priority=${priorityMode}&tab=${tab}`);
+        navigate(`/game?mode=${mode}&priority=${priorityMode}&dict=${tab}`);
     };
 
     const customAccuracy = getRangeAccuracy(parseInt(customStart), parseInt(customEnd));


### PR DESCRIPTION
### Motivation
- Fix a bug where the priority-mode buttons ("プレイ回数が少ない順" / "正答率が低い順") navigated with a `tab` query instead of `dict`, causing the selected dictionary to be lost.

### Description
- Change in `src/Select.js`: call `navigate` with `dict` instead of `tab` for priority-mode navigation (`navigate(`/game?mode=${mode}&priority=${priorityMode}&dict=${tab}`)`).

### Testing
- Ran `npm run build` and the production build completed successfully (the output contained unrelated ESLint warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec7186ce9c8328ad9e1d27e1e63221)