### PR TITLE
Persist correct/wrong counts per dictionary and pass `dict` through game flow

### DIFF
--- a/src/Game.js
+++ b/src/Game.js
@@ -117,8 +117,8 @@ function buildQuestionList() {
         return eitango.slice(start_num - 1, end_num);
     }
     if (priority_mode === "leastPlayed50") {
-        const correctCounts = getCorrectCounts();
-        const wrongCounts = getWrongCounts();
+        const correctCounts = getCorrectCounts(dict);
+        const wrongCounts = getWrongCounts(dict);
         return eitango
             .map((item, index) => {
                 const english = item[0];
@@ -133,8 +133,8 @@ function buildQuestionList() {
             .map((entry) => entry.item);
     }
     if (priority_mode === "lowAccuracy50") {
-        const correctCounts = getCorrectCounts();
-        const wrongCounts = getWrongCounts();
+        const correctCounts = getCorrectCounts(dict);
+        const wrongCounts = getWrongCounts(dict);
         return eitango
             .map((item, index) => {
                 const english = item[0];
@@ -417,7 +417,7 @@ function onMessage(event) {
             document.querySelector(".l_end").innerHTML = data.end_num;
             playingList.forEach(name => addPersonIntoLoading(name));
             setTimeout(() => {
-                navigate("/multiplay?&start=" + data.start_num + "&end=" + data.end_num);
+                navigate("/multiplay?&start=" + data.start_num + "&end=" + data.end_num + "&dict=" + dict);
                 ws.close();
             }, 5000);
         }
@@ -584,9 +584,7 @@ function Game() {
                 const correct_japanese = question_list[q_num][1];
                 if (selected_japanese === correct_japanese) {
                     if (!currentQuestionHadMistake) {
-                        if (!isDictMode) {
-                            incrementCorrectCount(question_list[q_num][0]);
-                        }
+                        incrementCorrectCount(question_list[q_num][0], dict);
                         correct_answers++;
                     }
                     document.querySelector(".answer").textContent = `${question_list[q_num][0]} = ${correct_japanese}`;
@@ -603,9 +601,7 @@ function Game() {
                     next_question();
                 } else {
                     currentQuestionHadMistake = true;
-                    if (!isDictMode) {
-                        incrementWrongCount(question_list[q_num][0]);
-                    }
+                    incrementWrongCount(question_list[q_num][0], dict);
                     wrong_answers++;
                     button.style.backgroundColor = "lightgray";
                     button.style.boxShadow = "0 5px gray";

--- a/src/Multiplay.js
+++ b/src/Multiplay.js
@@ -431,6 +431,7 @@ function MultiPlay() {
     navigate = useNavigate();
     const location = useLocation();
     const params = new URLSearchParams(location.search);
+    const dict = params.get("dict") || "0";
     const [value, setValue] = useState("");
 
     function logout() {
@@ -481,7 +482,7 @@ function MultiPlay() {
                 const correct_japanese = question_list[q_num][1];
                 if (selected_japanese === correct_japanese) {
                     if (!currentQuestionHadMistake) {
-                        incrementCorrectCount(question_list[q_num][0]);
+                        incrementCorrectCount(question_list[q_num][0], dict);
                         correct_answers++;
                     }
                     document.querySelector(".answer").textContent = `${question_list[q_num][0]} = ${correct_japanese}`;
@@ -499,7 +500,7 @@ function MultiPlay() {
                     next_question();
                 } else {
                     currentQuestionHadMistake = true;
-                    incrementWrongCount(question_list[q_num][0]);
+                    incrementWrongCount(question_list[q_num][0], dict);
                     wrong_answers++;
                     button.style.backgroundColor = "lightgray";
                     button.style.boxShadow = "0 5px gray";

--- a/src/wrongCountStorage.js
+++ b/src/wrongCountStorage.js
@@ -1,9 +1,37 @@
 const WRONG_STORAGE_KEY = "wrong_counts_v1";
 const CORRECT_STORAGE_KEY = "correct_counts_v1";
+const MIGRATION_STORAGE_KEY_PREFIX = "counts_dict_migration_v1_done";
 
-export function getWrongCounts() {
+function normalizeDictId(dictId) {
+    if (dictId === undefined || dictId === null || dictId === "") return "0";
+    return String(dictId);
+}
+
+function buildStorageKey(baseKey, dictId) {
+    return `${baseKey}_dict_${normalizeDictId(dictId)}`;
+}
+
+function migrateLegacyCountsIfNeeded(baseKey, dictId) {
+    const normalizedDictId = normalizeDictId(dictId);
+    if (normalizedDictId !== "0") return;
+    const migrationStatusKey = `${MIGRATION_STORAGE_KEY_PREFIX}_${baseKey}`;
+    if (localStorage.getItem(migrationStatusKey) === "1") return;
+
+    const newStorageKey = buildStorageKey(baseKey, normalizedDictId);
+    const current = localStorage.getItem(newStorageKey);
+    const legacy = localStorage.getItem(baseKey);
+    if (!current && legacy) {
+        localStorage.setItem(newStorageKey, legacy);
+    }
+
+    localStorage.setItem(migrationStatusKey, "1");
+}
+
+export function getWrongCounts(dictId) {
     try {
-        const raw = localStorage.getItem(WRONG_STORAGE_KEY);
+        migrateLegacyCountsIfNeeded(WRONG_STORAGE_KEY, dictId);
+        const storageKey = buildStorageKey(WRONG_STORAGE_KEY, dictId);
+        const raw = localStorage.getItem(storageKey);
         if (!raw) return {};
         const parsed = JSON.parse(raw);
         return parsed && typeof parsed === "object" ? parsed : {};
@@ -12,9 +40,11 @@ export function getWrongCounts() {
     }
 }
 
-export function getCorrectCounts() {
+export function getCorrectCounts(dictId) {
     try {
-        const raw = localStorage.getItem(CORRECT_STORAGE_KEY);
+        migrateLegacyCountsIfNeeded(CORRECT_STORAGE_KEY, dictId);
+        const storageKey = buildStorageKey(CORRECT_STORAGE_KEY, dictId);
+        const raw = localStorage.getItem(storageKey);
         if (!raw) return {};
         const parsed = JSON.parse(raw);
         return parsed && typeof parsed === "object" ? parsed : {};
@@ -23,16 +53,18 @@ export function getCorrectCounts() {
     }
 }
 
-export function incrementWrongCount(englishWord) {
+export function incrementWrongCount(englishWord, dictId) {
     if (!englishWord) return;
-    const counts = getWrongCounts();
+    const storageKey = buildStorageKey(WRONG_STORAGE_KEY, dictId);
+    const counts = getWrongCounts(dictId);
     counts[englishWord] = (counts[englishWord] || 0) + 1;
-    localStorage.setItem(WRONG_STORAGE_KEY, JSON.stringify(counts));
+    localStorage.setItem(storageKey, JSON.stringify(counts));
 }
 
-export function incrementCorrectCount(englishWord) {
+export function incrementCorrectCount(englishWord, dictId) {
     if (!englishWord) return;
-    const counts = getCorrectCounts();
+    const storageKey = buildStorageKey(CORRECT_STORAGE_KEY, dictId);
+    const counts = getCorrectCounts(dictId);
     counts[englishWord] = (counts[englishWord] || 0) + 1;
-    localStorage.setItem(CORRECT_STORAGE_KEY, JSON.stringify(counts));
+    localStorage.setItem(storageKey, JSON.stringify(counts));
 }


### PR DESCRIPTION
### Motivation

- Introduce per-dictionary scoping for correct/wrong answer counts so multiple dictionaries can maintain independent statistics.
- Ensure multiplayer navigation preserves the selected dictionary so counts are recorded against the correct dataset.
- Migrate legacy single-key localStorage data into the new per-dictionary format for existing users.

### Description

- Added `dict` URL propagation in `Game.js` and `Multiplay.js` and updated code paths to pass `dict` into counting functions so statistics are stored per-dictionary.
- Refactored `wrongCountStorage.js` to accept a `dictId`, to normalize `dict` values, to build per-dictionary storage keys, and to perform a one-time migration of legacy storage into the new key for the default dictionary (`0`).
- Updated `getWrongCounts`, `getCorrectCounts`, `incrementWrongCount`, and `incrementCorrectCount` to use per-dictionary keys and to persist counts under those keys.
- Minor UI/navigation change to include `&dict=` when navigating from matchmaking to the multiplayer game.

### Testing

- Ran `npm run build` to verify the app builds successfully and the modified modules compile without errors (build succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eec6225f98832887b742d3505fdfab)