### PR TITLE
Enable accuracy display and priority modes for 速読英単語 tab

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -30,11 +30,12 @@ function Select() {
     const [tab, setTab] = useState(0);
 
     useEffect(() => {
-        fetch(`${process.env.PUBLIC_URL}/eitango.json`)
+        const jsonFile = tab === 0 ? "eitango.json" : "sokutan.json";
+        fetch(`${process.env.PUBLIC_URL}/${jsonFile}`)
             .then(res => res.json())
             .then(data => setWords(data))
             .catch(err => console.error(err));
-    }, []);
+    }, [tab]);
 
     useEffect(() => {
         localStorage.setItem("customStart", customStart);
@@ -48,10 +49,10 @@ function Select() {
     const mode = params.get("mode") || "alone";
 
     const stats = useMemo(() => {
-        const correctCounts = getCorrectCounts();
-        const wrongCounts = getWrongCounts();
+        const correctCounts = getCorrectCounts(tab);
+        const wrongCounts = getWrongCounts(tab);
         return { correctCounts, wrongCounts };
-    }, []);
+    }, [tab]);
 
     const getRangeAccuracy = (start, end) => {
         if (words.length === 0) return null;
@@ -74,21 +75,26 @@ function Select() {
         return ((accuracySum / wordCount) * 100).toFixed(1);
     };
 
-    // 1~1800まで100区切りでボタンを生成
-    const buttons = [];
-    for (let i = 0; i < 18; i++) {
-        const start = i * 100 + 1;
-        const end = (i + 1) * 100;
-        const accuracy = getRangeAccuracy(start, end);
-        buttons.push(<SelectButton key={i} start={start} end={end} mode={mode} accuracy={accuracy} tab={0} />);
-    }
-
-    const buttons2 = [];
-    for (let i = 0; i < 19; i++) {
-        const start = i * 100 + 1;
-        const end = (i + 1) * 100;
-        buttons2.push(<SelectButton key={i} start={start} end={end} mode={mode} tab={1} />);
-    }
+    const createRangeButtons = (targetTab) => {
+        const buttonCount = Math.ceil(words.length / 100);
+        const rangeButtons = [];
+        for (let i = 0; i < buttonCount; i++) {
+            const start = i * 100 + 1;
+            const end = Math.min((i + 1) * 100, words.length);
+            const accuracy = getRangeAccuracy(start, end);
+            rangeButtons.push(
+                <SelectButton
+                    key={`${targetTab}-${i}`}
+                    start={start}
+                    end={end}
+                    mode={mode}
+                    accuracy={accuracy}
+                    tab={targetTab}
+                />
+            );
+        }
+        return rangeButtons;
+    };
 
     const handleCustomStart = (tab) => {
         const start = parseInt(customStart);
@@ -126,7 +132,7 @@ function Select() {
             <div className="slider">
                 <div className="buttonContainer">
                     <div className="slide" style={{ transform: `translateX(-${tab * 106}%)` }}>
-                        {mode === "alone" && (
+                        {mode === "alone" && tab === 0 && (
                             <div className="priorityModes">
                                 <button
                                     className="priorityModeButton"
@@ -142,7 +148,7 @@ function Select() {
                                 </button>
                             </div>
                         )}
-                        {buttons}
+                        {createRangeButtons(0)}
                         <div className="customRange">
                             <input
                                 type="number"
@@ -163,24 +169,24 @@ function Select() {
                             </button>
                         </div>
                     </div>
-                    <div className="slide accuracy_hidden" style={{ transform: `translateX(-${tab * 106}%)` }}>
-                        {/* {mode === "alone" && (
+                    <div className="slide" style={{ transform: `translateX(-${tab * 106}%)` }}>
+                        {mode === "alone" && tab === 1 && (
                             <div className="priorityModes">
                                 <button
                                     className="priorityModeButton"
-                                    onClick={() => navigatePriorityMode("leastPlayed50")}
+                                    onClick={() => navigatePriorityMode("leastPlayed50", 1)}
                                 >
                                     プレイ回数が少ない順
                                 </button>
                                 <button
                                     className="priorityModeButton"
-                                    onClick={() => navigatePriorityMode("lowAccuracy50")}
+                                    onClick={() => navigatePriorityMode("lowAccuracy50", 1)}
                                 >
                                     正答率が低い順
                                 </button>
                             </div>
-                        )} */}
-                        {buttons2}
+                        )}
+                        {createRangeButtons(1)}
                         <div className="customRange">
                             <input
                                 type="number"


### PR DESCRIPTION
### Motivation
- Make the 速読英単語 (sokutan) tab behave like the existing dict=0 flow so it shows per-word accuracy and supports prioritized practice modes.
- Ensure accuracy and priority selections operate per-dictionary (i.e. separate stats for `dict=0` and `dict=1`).

### Description
- Load word data based on the active tab by fetching either `eitango.json` or `sokutan.json` in the `useEffect` (`tab` dependency) so displayed ranges and accuracy use the active dictionary.
- Read counts with the selected dictionary id by calling `getCorrectCounts(tab)` and `getWrongCounts(tab)` so accuracy is computed per-dictionary for the UI.
- Add priority mode buttons on the 速読英単語 tab and route them with `dict=1` (`/game?mode=...&priority=...&dict=1`) so "プレイ回数が少ない順" and "正答率が低い順" work for sokutan.
- Replace the hardcoded 100-range button lists with `createRangeButtons` that generates range buttons dynamically from the loaded `words` array and shows range accuracy for each tab.

### Testing
- Ran a production build with `npm run build`, which completed successfully and produced the optimized build artifacts; the change does not introduce build errors (existing ESLint warnings remain unrelated).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efe62a03e08328b39e9ae437967e56)