### PR TITLE
速読英単語の優先モードでの問題数カウント初期化を修正

### DIFF
--- a/src/Game.js
+++ b/src/Game.js
@@ -24,7 +24,6 @@ let priority_mode;
 let eitango;
 let navigate;
 let selected_question_count = 0;
-let isDictMode = false;
 
 // setInterval, requestAnimationFrameのID管理用
 let intervalIds = [];
@@ -99,6 +98,7 @@ function StartGame() {
     selected_question_count = builtQuestionList.length;
     question_list = builtQuestionList;
     default_question_list = builtQuestionList.slice();
+    initializeBlocks(builtQuestionList.length);
     // シャッフル
     for (let i = question_list.length - 1; i > 0; i--) {
         const j = Math.floor(Math.random() * (i + 1));
@@ -113,9 +113,6 @@ function StartGame() {
 
 function buildQuestionList() {
     if (!Array.isArray(eitango) || eitango.length === 0) return [];
-    if (isDictMode) {
-        return eitango.slice(start_num - 1, end_num);
-    }
     if (priority_mode === "leastPlayed50") {
         const correctCounts = getCorrectCounts(dict);
         const wrongCounts = getWrongCounts(dict);
@@ -154,6 +151,18 @@ function buildQuestionList() {
             .map((entry) => entry.item);
     }
     return eitango.slice(start_num - 1, end_num);
+}
+
+function initializeBlocks(totalBlocks) {
+    blocks = [];
+    for (let i = 0; i < totalBlocks; i++) {
+        blocks.push({
+            x: 0,
+            y: canvas.height - blockHeight * (i + 1),
+            vy: 0,
+            color: "#4CAF50"
+        });
+    }
 }
 
 
@@ -502,7 +511,6 @@ function Game() {
     useEffect(() => {
         resetGameState();
         mode = params.get("mode");
-        isDictMode = params.get("dict") === "1";
         priority_mode = params.get("priority") || "";
         dict = params.get("dict") || "";
         start_num = parseInt(params.get("start")) || 1;
@@ -567,16 +575,6 @@ function Game() {
         canvas.width = 200;
         canvas.height = 1000;
         ctx.translate(100, 0);
-        // 初期化
-        const totalBlocks = priority_mode ? 50 : (end_num - start_num + 1);
-        for (let i = 0; i < totalBlocks; i++) {
-            blocks.push({
-                x: 0,
-                y: canvas.height - blockHeight * (i + 1),
-                vy: 0,
-                color: "#4CAF50"
-            });
-        }
 
         document.querySelectorAll(".Japanese").forEach(button => {
             button.addEventListener("click", () => {


### PR DESCRIPTION
### Motivation
- 優先モード（`leastPlayed50` / `lowAccuracy50`）でプレイした際に右下の問題数表示が `1750/1800` のようにずれる不具合を修正するための変更です。これは出題リストとブロック（画面右下の分母）を事前に別基準で初期化していたことが原因でした。

### Description
- `buildQuestionList()` の分岐を整理して、優先モードを全辞書（`eitango`/`sokutan`）で正しく適用するようにしました（`dict` によって優先モードがスキップされないよう修正）。
- ゲーム開始時に実際に作成した問題リスト長を渡してブロックを初期化する `initializeBlocks(totalBlocks)` ヘルパーを追加し、`StartGame()` から `builtQuestionList.length` で初期化するようにしました。
- `useEffect` 内での事前ブロック生成を削除して、ブロック初期化の起点をゲーム開始時の実データに統一しました。
- 変更箇所は主に `src/Game.js`（`StartGame()`, `buildQuestionList()`, `initializeBlocks()` の追加・移動）です。

### Testing
- `npm run build` を実行してビルドが成功することを確認しました（ビルドは警告ありでコンパイル成功、今回の修正によるエラーは発生していません）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69effb6c50b48328b17993b5b3a58192)