### PR TITLE
ホーム画面に設定ボタンを追加し、音量設定ページを実装

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -7,6 +7,7 @@ import Game from "./Game";
 import Result from "./Result";
 import Multiplay from "./Multiplay";
 import MistakeStats from "./MistakeStats";
+import Settings from "./Settings";
 import './App.css';
 
 function AnimatedRoutes() {
@@ -23,6 +24,7 @@ function AnimatedRoutes() {
         <Route path="/result" element={<Result />} />
         <Route path="/multiplay" element={<Multiplay />} />
         <Route path="/mistakes" element={<MistakeStats />} />
+        <Route path="/settings" element={<Settings />} />
       </Routes>
     </AnimatePresence>
   );

--- a/src/Game.js
+++ b/src/Game.js
@@ -5,6 +5,7 @@ import './Loading.css';
 import { WebHaptics, defaultPatterns } from "https://cdn.skypack.dev/web-haptics";
 import { useState, useEffect } from "react";
 import { getCorrectCounts, getWrongCounts, incrementCorrectCount, incrementWrongCount } from "./wrongCountStorage";
+import { getVolumeLevel } from "./settingsStorage";
 
 const slideVariants = {
     initial: { x: "100%", opacity: 0 },
@@ -173,6 +174,7 @@ function speakQuestionWord(word) {
     utterance.lang = "en-US";
     utterance.rate = 0.9;
     utterance.pitch = 1;
+    utterance.volume = getVolumeLevel();
     window.speechSynthesis.speak(utterance);
 }
 
@@ -286,6 +288,7 @@ function breakBlock() {
 
     // break.mp3を再生
     const audio = new Audio(`${process.env.PUBLIC_URL}/break.mp3`);
+    audio.volume = getVolumeLevel();
     audio.play();
 
     if (blocks.length === 0) return;
@@ -374,6 +377,7 @@ function update() {
     if (Date.now() - start_time > max_time) {
         if (!beeped) {
             const audio = new Audio(`${process.env.PUBLIC_URL}/beep.mp3`);
+            audio.volume = getVolumeLevel();
             audio.play();
             // 失敗時、カウント中のbtb_countを累計に加算
             btb_total += btb_count;
@@ -615,6 +619,7 @@ function Game() {
                         question_list.splice(randomNum, 0, question_list[q_num]);
                     }
                     const audio = new Audio(`${process.env.PUBLIC_URL}/wrong.mp3`);
+                    audio.volume = getVolumeLevel();
                     audio.play();
                     number_of_questions += 2;
                 }

--- a/src/Home.css
+++ b/src/Home.css
@@ -1,7 +1,18 @@
 .Home{
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   gap: 30vh;
+}
+
+.settingsButton {
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  color: inherit;
+  text-decoration: none;
+  font-size: 32px;
+  z-index: 2;
 }

--- a/src/Home.js
+++ b/src/Home.js
@@ -20,6 +20,13 @@ function Home() {
             className="Home"
             onClick={() => navigate("/mode")}
             >
+            <Link
+                to="/settings"
+                className="settingsButton material-icons"
+                onClick={(e) => e.stopPropagation()}
+            >
+                settings
+            </Link>
             <h1 className="title">英単語1800</h1>
             Tap To Start
         </motion.div>);

--- a/src/Multiplay.js
+++ b/src/Multiplay.js
@@ -5,6 +5,7 @@ import './Loading.css';
 import { WebHaptics, defaultPatterns } from "https://cdn.skypack.dev/web-haptics";
 import { useEffect, useState } from "react";
 import { incrementCorrectCount, incrementWrongCount } from "./wrongCountStorage";
+import { getVolumeLevel } from "./settingsStorage";
 
 const slideVariants = {
     initial: { x: "100%", opacity: 0 },
@@ -75,6 +76,7 @@ function speakQuestionWord(word) {
     utterance.lang = "en-US";
     utterance.rate = 0.9;
     utterance.pitch = 1;
+    utterance.volume = getVolumeLevel();
     window.speechSynthesis.speak(utterance);
 }
 
@@ -189,6 +191,7 @@ function breakBlock() {
 
     // break.mp3を再生
     const audio = new Audio(`${process.env.PUBLIC_URL}/break.mp3`);
+    audio.volume = getVolumeLevel();
     audio.play();
 
     if (blocks.length === 0) return;
@@ -279,6 +282,7 @@ function update() {
             let enemy = playingList.filter(i => i !== localStorage.getItem("user_name"))[Math.floor(Math.random() * (playingList.length - 1))];
             sendMessage({ type: "btb", count: btb_count, user_name: localStorage.getItem("user_name"), enemy });
             const audio = new Audio(`${process.env.PUBLIC_URL}/beep.mp3`);
+            audio.volume = getVolumeLevel();
             audio.play().catch(e => { /* 失敗しても無視 */ });
             // 失敗時、カウント中のbtb_countを累計に加算
             btb_total += btb_count;
@@ -326,6 +330,7 @@ function onMessage(event) {
         if (data.enemy === localStorage.getItem("user_name") && data.count > 0) {
             setTimeout(() => {
                 const audio = new Audio(`${process.env.PUBLIC_URL}/damage.mp3`);
+                audio.volume = getVolumeLevel();
                 audio.play().catch(e => { /* 失敗しても無視 */ });
             }, 1200);
             for (var i = 0; i < data.count; i++) {
@@ -516,6 +521,7 @@ function MultiPlay() {
                         question_list.splice(randomNum, 0, question_list[q_num]);
                     }
                     const audio = new Audio(`${process.env.PUBLIC_URL}/wrong.mp3`);
+                    audio.volume = getVolumeLevel();
                     audio.play();
                     number_of_questions += 2;
                 }

--- a/src/Settings.css
+++ b/src/Settings.css
@@ -1,0 +1,20 @@
+.Settings {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+}
+
+.volumeLabel {
+  font-size: 1.2rem;
+}
+
+#volume-range {
+  width: min(360px, 80vw);
+}
+
+.backButton {
+  margin-top: 12px;
+}

--- a/src/Settings.js
+++ b/src/Settings.js
@@ -1,0 +1,49 @@
+import { motion } from "framer-motion";
+import { Link } from "react-router-dom";
+import { useState } from "react";
+import { getVolumeLevel, setVolumeLevel } from "./settingsStorage";
+import "./Settings.css";
+
+const slideVariants = {
+  initial: { x: "100%", opacity: 0 },
+  animate: { x: 0, opacity: 1 },
+  exit: { x: "-100%", opacity: 0 },
+};
+
+function Settings() {
+  const [volume, setVolume] = useState(getVolumeLevel());
+
+  const handleChange = (event) => {
+    const nextVolume = Number(event.target.value);
+    setVolume(nextVolume);
+    setVolumeLevel(nextVolume);
+  };
+
+  return (
+    <motion.div
+      variants={slideVariants}
+      initial="initial"
+      animate="animate"
+      exit="exit"
+      transition={{ duration: 0.3 }}
+      className="Settings"
+    >
+      <h1>設定</h1>
+      <label className="volumeLabel" htmlFor="volume-range">
+        音量: {Math.round(volume * 100)}%
+      </label>
+      <input
+        id="volume-range"
+        type="range"
+        min="0"
+        max="1"
+        step="0.05"
+        value={volume}
+        onChange={handleChange}
+      />
+      <Link to="/" className="backButton">ホームへ戻る</Link>
+    </motion.div>
+  );
+}
+
+export default Settings;

--- a/src/settingsStorage.js
+++ b/src/settingsStorage.js
@@ -1,0 +1,15 @@
+const VOLUME_STORAGE_KEY = "volume_level_v1";
+const DEFAULT_VOLUME = 1;
+
+export function getVolumeLevel() {
+  const stored = localStorage.getItem(VOLUME_STORAGE_KEY);
+  if (stored === null) return DEFAULT_VOLUME;
+  const parsed = Number(stored);
+  if (Number.isNaN(parsed)) return DEFAULT_VOLUME;
+  return Math.min(1, Math.max(0, parsed));
+}
+
+export function setVolumeLevel(volume) {
+  const normalized = Math.min(1, Math.max(0, Number(volume)));
+  localStorage.setItem(VOLUME_STORAGE_KEY, String(normalized));
+}


### PR DESCRIPTION
### Motivation
- ホーム画面からアクセスできる設定ページを追加して、効果音および読み上げの音量をユーザ設定で調整できるようにするための変更です。

### Description
- ルーティングに `Settings` コンポーネントを追加して `/settings` ルートを実装し、`src/App.js` を更新しました。
- ホーム画面に右上の設定ボタン（歯車アイコン）を追加し、ホームのタップ遷移と干渉しないように `event.stopPropagation()` を入れた上で `src/Home.js` と `src/Home.css` を更新しました。
- 音量の永続化ユーティリティとして `src/settingsStorage.js` を追加し、`getVolumeLevel` / `setVolumeLevel` を提供します。
- 設定 UI を `src/Settings.js` / `src/Settings.css` として追加し、スライダーで 0〜1 の音量を選べるようにしました。
- ゲーム側（`src/Game.js` と `src/Multiplay.js`）で読み上げ音量 (`SpeechSynthesisUtterance.volume`) と効果音 (`Audio.volume`) に `getVolumeLevel()` の値を反映するように変更しました（`break.mp3` / `beep.mp3` / `wrong.mp3` / `damage.mp3` 等）。

### Testing
- 実行した自動テスト: `npm test -- --watch=false --passWithNoTests` を実行しましたが、テスト環境で `Cannot find module 'react-router-dom' from 'src/App.js'` のエラーが出て失敗しました（既存のテストランナー環境依存の問題のため、今回の変更自体はローカルのビルド/実行で確認してください）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01122b379883288907363fb2a36231)