### PR TITLE
設定でプレイ時の触覚フィードバックを切替可能にする

### DIFF
--- a/src/Game.js
+++ b/src/Game.js
@@ -5,7 +5,7 @@ import './Loading.css';
 import { WebHaptics, defaultPatterns } from "https://cdn.skypack.dev/web-haptics";
 import { useState, useEffect } from "react";
 import { getCorrectCounts, getWrongCounts, incrementCorrectCount, incrementWrongCount } from "./wrongCountStorage";
-import { getVolumeLevel } from "./settingsStorage";
+import { getHapticsEnabled, getVolumeLevel } from "./settingsStorage";
 
 const slideVariants = {
     initial: { x: "100%", opacity: 0 },
@@ -197,7 +197,9 @@ function next_question() {
     document.querySelector(".Japanese2").textContent = options[1];
     document.querySelector(".Japanese3").textContent = options[2];
     document.querySelector(".Japanese4").textContent = options[3];
-    haptics.trigger(defaultPatterns.heavy);
+    if (getHapticsEnabled()) {
+        haptics.trigger(defaultPatterns.heavy);
+    }
     currentQuestionHadMistake = false;
 
     if (Date.now() - start_time > max_time) {
@@ -607,7 +609,9 @@ function Game() {
                     wrong_answers++;
                     button.style.backgroundColor = "lightgray";
                     button.style.boxShadow = "0 5px gray";
-                    haptics.trigger(defaultPatterns.error);
+                    if (getHapticsEnabled()) {
+                        haptics.trigger(defaultPatterns.error);
+                    }
                     for (var i = 0; i < 2; i++) {
                         let randomNum;
                         if (i === 0) {

--- a/src/Multiplay.js
+++ b/src/Multiplay.js
@@ -5,7 +5,7 @@ import './Loading.css';
 import { WebHaptics, defaultPatterns } from "https://cdn.skypack.dev/web-haptics";
 import { useEffect, useState } from "react";
 import { incrementCorrectCount, incrementWrongCount } from "./wrongCountStorage";
-import { getVolumeLevel } from "./settingsStorage";
+import { getHapticsEnabled, getVolumeLevel } from "./settingsStorage";
 
 const slideVariants = {
     initial: { x: "100%", opacity: 0 },
@@ -99,7 +99,9 @@ function next_question() {
     document.querySelector(".Japanese2").textContent = options[1];
     document.querySelector(".Japanese3").textContent = options[2];
     document.querySelector(".Japanese4").textContent = options[3];
-    haptics.trigger(defaultPatterns.heavy);
+    if (getHapticsEnabled()) {
+        haptics.trigger(defaultPatterns.heavy);
+    }
     currentQuestionHadMistake = false;
 
     if (Date.now() - start_time > max_time) {
@@ -509,7 +511,9 @@ function MultiPlay() {
                     wrong_answers++;
                     button.style.backgroundColor = "lightgray";
                     button.style.boxShadow = "0 5px gray";
-                    haptics.trigger(defaultPatterns.error);
+                    if (getHapticsEnabled()) {
+                        haptics.trigger(defaultPatterns.error);
+                    }
                     for (var i = 0; i < 2; i++) {
                         let randomNum;
                         if (i === 0) {

--- a/src/Settings.css
+++ b/src/Settings.css
@@ -78,3 +78,9 @@ input[type="range"]:hover::-webkit-slider-thumb {
 input[type="range"]:active::-webkit-slider-thumb {
   transform: scale(0.95);
 }
+.toggleRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 1rem;
+}

--- a/src/Settings.js
+++ b/src/Settings.js
@@ -1,7 +1,12 @@
 import { motion } from "framer-motion";
 import { Link } from "react-router-dom";
 import { useState } from "react";
-import { getVolumeLevel, setVolumeLevel } from "./settingsStorage";
+import {
+  getHapticsEnabled,
+  getVolumeLevel,
+  setHapticsEnabled,
+  setVolumeLevel,
+} from "./settingsStorage";
 import "./Settings.css";
 
 const slideVariants = {
@@ -12,11 +17,18 @@ const slideVariants = {
 
 function Settings() {
   const [volume, setVolume] = useState(getVolumeLevel());
+  const [hapticsEnabled, setHapticsEnabledState] = useState(getHapticsEnabled());
 
   const handleChange = (event) => {
     const nextVolume = Number(event.target.value);
     setVolume(nextVolume);
     setVolumeLevel(nextVolume);
+  };
+
+  const handleHapticsChange = (event) => {
+    const enabled = event.target.checked;
+    setHapticsEnabledState(enabled);
+    setHapticsEnabled(enabled);
   };
 
   return (
@@ -41,6 +53,15 @@ function Settings() {
         value={volume}
         onChange={handleChange}
       />
+      <label className="toggleRow" htmlFor="haptics-enabled">
+        <input
+          id="haptics-enabled"
+          type="checkbox"
+          checked={hapticsEnabled}
+          onChange={handleHapticsChange}
+        />
+        プレイ時の触覚フィードバック
+      </label>
       <Link to="/" className="backButton">ホームへ戻る</Link>
     </motion.div>
   );

--- a/src/settingsStorage.js
+++ b/src/settingsStorage.js
@@ -13,3 +13,16 @@ export function setVolumeLevel(volume) {
   const normalized = Math.min(1, Math.max(0, Number(volume)));
   localStorage.setItem(VOLUME_STORAGE_KEY, String(normalized));
 }
+
+const HAPTICS_STORAGE_KEY = "haptics_enabled_v1";
+const DEFAULT_HAPTICS_ENABLED = true;
+
+export function getHapticsEnabled() {
+  const stored = localStorage.getItem(HAPTICS_STORAGE_KEY);
+  if (stored === null) return DEFAULT_HAPTICS_ENABLED;
+  return stored === "true";
+}
+
+export function setHapticsEnabled(enabled) {
+  localStorage.setItem(HAPTICS_STORAGE_KEY, String(Boolean(enabled)));
+}


### PR DESCRIPTION
### Motivation
- プレイ中の触覚フィードバックをユーザー設定でオン/オフできるようにして、好みに応じた体験を提供するため。 
- 設定は永続化して既存デフォルト動作（オン）を維持することで既存ユーザーの挙動を崩さないようにするため。 

### Description
- `src/settingsStorage.js` に `getHapticsEnabled` と `setHapticsEnabled` を追加して `localStorage` に `haptics_enabled_v1` を保存/読み込みする仕組みを実装しました（既定値は `true`）。
- `src/Settings.js` にチェックボックス UI を追加して状態を `getHapticsEnabled`/`setHapticsEnabled` と連動させるハンドラを追加しました。 
- `src/Settings.css` にトグル行のスタイル `.toggleRow` を追加しました。 
- `src/Game.js` と `src/Multiplay.js` で `haptics.trigger(...)` の呼び出しを `if (getHapticsEnabled()) { ... }` でラップして、設定がオフのときはハプティクスを発火しないように変更しました。 

### Testing
- 実行した自動テストは `npm test -- --watchAll=false` のみで、既存の環境依存（`Cannot find module 'react-router-dom' from 'src/App.js'`）によりテストは失敗しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06e94ca78883288ba4077910230383)