### PR TITLE
Improve UI design across non-game pages

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2,9 +2,13 @@
 @import url('https://fonts.googleapis.com/css2?family=Russo+One&display=swap');
 
 body{
-  background-color: #fff2c7;
+  background:
+    radial-gradient(circle at 15% 20%, rgba(255, 255, 255, 0.6), transparent 45%),
+    radial-gradient(circle at 80% 0%, rgba(255, 214, 117, 0.55), transparent 45%),
+    linear-gradient(160deg, #fff6d8 0%, #ffecc2 100%);
   font-family: "Noto Sans JP", sans-serif;
   overflow: hidden;
+  color: #2c2a24;
 }
 
 #root {
@@ -19,14 +23,32 @@ body{
 
 
 button {
-    background-color: #2196F3;
+    background: linear-gradient(135deg, #2b9dff, #1674f3);
     color: white;
     padding: 12px 24px;
     border: none;
-    border-radius: 8px;
-    box-shadow: 0 5px #0b7dda;
+    border-radius: 12px;
+    box-shadow: 0 5px 0 #0b5fc9, 0 12px 28px rgba(20, 84, 164, 0.2);
     cursor: pointer;
     width: 100%;
-    font-size: 1.3em;
+    font-size: 1.08rem;
+    font-weight: 700;
     margin: 10px 0;
+    transition: transform 0.15s ease, box-shadow 0.15s ease, filter 0.15s ease;
+}
+
+button:hover {
+    filter: brightness(1.03);
+    transform: translateY(-1px);
+}
+
+button:active {
+    transform: translateY(3px);
+    box-shadow: 0 2px 0 #0b5fc9, 0 8px 16px rgba(20, 84, 164, 0.16);
+}
+
+button:disabled {
+    background: linear-gradient(135deg, #9fb7d6, #86a2c7);
+    box-shadow: 0 4px 0 #6d86a8;
+    cursor: not-allowed;
 }

--- a/src/Home.css
+++ b/src/Home.css
@@ -4,9 +4,18 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 30vh;
+  gap: 26vh;
   width: 100vw;
   height: 100vh;
+  text-align: center;
+  font-size: 1.15rem;
+  letter-spacing: 0.03em;
+}
+
+.Home .title {
+  font-size: clamp(2.2rem, 9vw, 4rem);
+  margin: 0;
+  text-shadow: 0 4px 12px rgba(255, 255, 255, 0.65);
 }
 
 .settingsButton {
@@ -15,6 +24,11 @@
   right: 20px;
   color: inherit;
   text-decoration: none;
-  font-size: 32px;
+  font-size: 34px;
   z-index: 2;
+  background: rgba(255, 255, 255, 0.78);
+  border: 1px solid rgba(255, 255, 255, 0.9);
+  border-radius: 999px;
+  padding: 8px;
+  backdrop-filter: blur(4px);
 }

--- a/src/MistakeStats.css
+++ b/src/MistakeStats.css
@@ -1,8 +1,8 @@
 .MistakeStats {
     width: 100%;
-    max-width: 800px;
+    max-width: 960px;
     height: 100%;
-    background: #f9fbff;
+    background: rgba(249, 251, 255, 0.68);
     padding: 20px;
     box-sizing: border-box;
     color: #222;
@@ -39,7 +39,7 @@
     overflow-x: auto;
     background: #fff;
     border-radius: 12px;
-    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.08);
+    box-shadow: 0 10px 26px rgba(0, 0, 0, 0.1);
 }
 
 .statsTable {

--- a/src/Mode.css
+++ b/src/Mode.css
@@ -6,17 +6,35 @@
   justify-content: center;
   width: 100%;
   height: 100%;
+  gap: 8px;
+  padding: 24px;
+  box-sizing: border-box;
+}
+
+.Mode .title {
+  margin-bottom: 8px;
+}
+
+.Mode button {
+  max-width: 460px;
 }
 
 .schedule {
   display: flex;
   flex-direction: column;
-  background-color: whitesmoke;
-  border: 2px solid black;
-  border-radius: 5px;
-  padding: 5px;
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(255, 255, 255, 0.9);
+  border-radius: 14px;
+  padding: 14px 16px;
   align-items: center;
   margin-top: 20px;
+  width: min(500px, 92vw);
+  box-shadow: 0 10px 24px rgba(58, 45, 10, 0.1);
+}
+
+.schedule .range {
+  margin-top: 8px;
+  font-weight: 700;
 }
 
 .changed-url {
@@ -24,8 +42,20 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  background: white;
-  padding: 10px;
+  background: rgba(255, 255, 255, 0.76);
+  padding: 14px;
   margin: 10px;
-  border-radius: 10px;
+  border-radius: 14px;
+  width: min(500px, 92vw);
+  box-sizing: border-box;
+  border: 1px solid rgba(255, 255, 255, 0.92);
+}
+
+.changed-url h3 {
+  margin: 0 0 8px;
+  font-size: 1rem;
+}
+
+.changed-url a {
+  font-weight: 700;
 }

--- a/src/Result.css
+++ b/src/Result.css
@@ -4,6 +4,9 @@
     align-items: center;
     justify-content: center;
     height: 100vh;
+    width: min(640px, 94vw);
+    margin: 0 auto;
+    gap: 12px;
 }
 
 .wide {
@@ -12,15 +15,21 @@
 
 .result {
     text-align: center;
+    background: rgba(255, 255, 255, 0.72);
+    width: 100%;
+    border-radius: 16px;
+    padding: 16px;
+    box-sizing: border-box;
+    border: 1px solid rgba(255, 255, 255, 0.92);
 }
 
 
 .rk-container {
-    width: 80vw;
+    width: 100%;
     margin: 20px auto;
     padding: 20px;
     background: #ffffff;
-    border-radius: 10px;
+    border-radius: 14px;
     font-family: Arial, sans-serif;
     display: none;
 }
@@ -31,7 +40,7 @@
     align-items: center;
     padding: 12px 16px;
     margin-bottom: 10px;
-    border-radius: 20px;
+    border-radius: 14px;
     border: 1px solid #ddd;
 }
 

--- a/src/Select.css
+++ b/src/Select.css
@@ -1,10 +1,13 @@
 .back {
-    color: gray;
+    color: #545454;
     text-decoration: none;
     font-size: 1em;
     position: absolute;
-    top: 0;
-    left: 0;
+    top: 8px;
+    left: 8px;
+    background: rgba(255, 255, 255, 0.75);
+    padding: 6px 10px;
+    border-radius: 999px;
 }
 
 .Select {
@@ -15,6 +18,7 @@
     justify-content: center;
     width: 100%;
     height: 100%;
+    gap: 4px;
 }
 
 .SelectButton:active {
@@ -28,7 +32,8 @@
     align-items: center;
     justify-content: center;
     padding: 10px;
-    height: 80px;
+    height: 88px;
+    border-radius: 14px;
 }
 
 .rangeText {
@@ -36,8 +41,8 @@
 }
 
 .accuracy {
-    font-size: 0.7em;
-    color: #eee;
+    font-size: 0.8em;
+    color: #e8f4ff;
     margin-top: 5px;
 }
 
@@ -51,9 +56,9 @@
     transition: transform 0.4s ease;
     height: 60vh;
     padding: 20px;
-    background: #00000010;
+    background: rgba(255, 255, 255, 0.4);
     margin-top: 20px;
-    border-radius: 10px;
+    border-radius: 16px;
     overflow-x: hidden;
     gap: 20px;
     width: 200%;
@@ -62,6 +67,7 @@
 .slide {
     overflow-y: scroll;
     width: 360px;
+    padding-right: 4px;
 }
 
 .priorityModes {
@@ -80,7 +86,10 @@
     display: flex;
     align-items: center;
     gap: 10px;
-    margin-bottom: 10px;
+    margin: 12px 0;
+    background: rgba(255, 255, 255, 0.65);
+    border-radius: 14px;
+    padding: 10px;
 }
 
 .customRange input {
@@ -111,7 +120,14 @@
 /* タブ */
 .tabs {
     display: flex;
-    gap: 20px;
+    gap: 12px;
+}
+
+.tabs button {
+    margin: 0;
+    width: auto;
+    min-width: 170px;
+    font-size: 0.95rem;
 }
 
 .tabs label {
@@ -128,6 +144,16 @@
 .slider {
     overflow-x: hidden;
     width: 400px;
+}
+
+@media (max-width: 480px) {
+    .slider {
+        width: 94vw;
+    }
+
+    .slide {
+        width: calc(94vw - 28px);
+    }
 }
 
 .accuracy_hidden>.SelectButton>.accuracy {

--- a/src/Settings.css
+++ b/src/Settings.css
@@ -5,6 +5,13 @@
   align-items: center;
   justify-content: center;
   gap: 16px;
+  width: min(560px, 94vw);
+  background: rgba(255, 255, 255, 0.68);
+  border: 1px solid rgba(255, 255, 255, 0.92);
+  border-radius: 18px;
+  box-shadow: 0 16px 36px rgba(47, 36, 8, 0.14);
+  padding: 28px 20px;
+  box-sizing: border-box;
 }
 
 .volumeLabel {
@@ -91,4 +98,6 @@ input[type="range"]:active::-webkit-slider-thumb {
   align-items: center;
   gap: 8px;
   font-size: 1rem;
+  width: min(360px, 88vw);
+  justify-content: flex-start;
 }


### PR DESCRIPTION
### Motivation
- Unify and modernize the visual design of non-game pages to improve clarity and consistency while leaving gameplay screens (`Game` / `Multiplay`) untouched. 
- Make navigation and utility pages easier to scan by introducing card-like containers, clearer typography, and improved spacing. 

### Description
- Restyled global layout and controls in `src/App.css` with layered background gradients, updated button visuals, and hover/active/disabled interaction states. 
- Updated `src/Home.css` to refine spacing, scale the title responsively, and make the settings button a visible glass-style circular control. 
- Converted mode-related UI in `src/Mode.css` to card-like schedule and notice blocks, tightened layout spacing, and added shadows and max-width constraints. 
- Improved range-selection UI in `src/Select.css` by styling the back control, making range buttons more tactile, polishing the custom-range input area, and adding responsive slider sizing. 
- Turned the settings page into a centered card container in `src/Settings.css` and improved toggle/slider layout for readability. 
- Polished result and ranking containers in `src/Result.css` to present results in a framed card and adjusted sizing for the ranking list. 
- Tweaked `src/MistakeStats.css` to increase allowed width, soften the background, and strengthen the table card shadow for consistency. 

### Testing
- Ran the production build with `npm run build` which completed successfully. 
- The build output included existing ESLint warnings from files outside the styling changes but did not block the build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14313da7e083289b5a2f7649e65459)