### PR TITLE
Cleanup off-screen block-break particles in Game and Multiplay

### DIFF
--- a/src/Game.js
+++ b/src/Game.js
@@ -345,18 +345,29 @@ function update() {
         ctx.strokeRect(b.x, b.y, blockWidth, blockHeight);
     });
 
-    // 破片
-    particles.forEach(p => {
+    // 破片（画面外に出たら削除）
+    for (let i = particles.length - 1; i >= 0; i--) {
+        const p = particles[i];
         p.vy += p.gravity;
         p.x += p.vx;
         p.y += p.vy;
+
+        if (
+            p.x + p.size < 0 ||
+            p.x > canvas.width ||
+            p.y + p.size < 0 ||
+            p.y > canvas.height
+        ) {
+            particles.splice(i, 1);
+            continue;
+        }
 
         ctx.fillStyle = p.color;
         ctx.fillRect(p.x, p.y, p.size, p.size);
 
         ctx.strokeStyle = "#000";
         ctx.strokeRect(p.x, p.y, p.size, p.size);
-    });
+    }
 
     // 右下の正解数/総問題数も毎フレーム更新
     const correctElem = document.querySelector('.corner-correct');

--- a/src/Multiplay.js
+++ b/src/Multiplay.js
@@ -253,18 +253,29 @@ function update() {
         ctx.strokeRect(b.x, b.y, blockWidth, blockHeight);
     });
 
-    // 破片
-    particles.forEach(p => {
+    // 破片（画面外に出たら削除）
+    for (let i = particles.length - 1; i >= 0; i--) {
+        const p = particles[i];
         p.vy += p.gravity;
         p.x += p.vx;
         p.y += p.vy;
+
+        if (
+            p.x + p.size < 0 ||
+            p.x > canvas.width ||
+            p.y + p.size < 0 ||
+            p.y > canvas.height
+        ) {
+            particles.splice(i, 1);
+            continue;
+        }
 
         ctx.fillStyle = p.color;
         ctx.fillRect(p.x, p.y, p.size, p.size);
 
         ctx.strokeStyle = "#000";
         ctx.strokeRect(p.x, p.y, p.size, p.size);
-    });
+    }
 
     // 右下の正解数/総問題数も毎フレーム更新
     const correctElem = document.querySelector('.corner-correct');


### PR DESCRIPTION
### Motivation
- Block-break particle fragments were allowed to remain after leaving the canvas, causing unnecessary array growth and extra per-frame work during long sessions.
- The change targets the broken-block effect shown in the lower-right canvas so the visual behavior stays correct while avoiding invisible lingering particles.

### Description
- Replace `particles.forEach(...)` with a reverse `for` loop inside the `update()` loop in `src/Game.js` and `src/Multiplay.js` to allow safe removal while iterating. 
- Add bounding checks that remove a particle when `p.x + p.size < 0 || p.x > canvas.width || p.y + p.size < 0 || p.y > canvas.height` to drop off-screen fragments. 
- Preserve existing on-screen rendering and physics (`p.vy`, `p.vx`, gravity) and keep all other `update()` behaviors unchanged. 
- Changes were committed with the message `Remove off-screen block break particles`.

### Testing
- No automated tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14d315c994832886da18cc9ecf5c23)