### PR TITLE
Throttle canvas render loop and cache HUD DOM accesses in Game and Multiplay

### DIFF
--- a/src/Game.js
+++ b/src/Game.js
@@ -88,6 +88,7 @@ function StartGame() {
 
     document.querySelector(".Ready").style.display = "none";
     document.querySelector(".Playing").style.display = "flex";
+    cacheHudElements();
     const builtQuestionList = buildQuestionList();
     if (builtQuestionList.length === 0) {
         alert("出題できる問題がありません。条件を変えてください。");
@@ -242,6 +243,21 @@ let playingList = [];
 let startSoonReceived = false;
 let startGameReceived = false;
 let currentQuestionHadMistake = false;
+let lastRenderTime = 0;
+const TARGET_FRAME_MS = 1000 / 30;
+let cornerCorrectElem = null;
+let cornerTotalElem = null;
+let btbCountElem = null;
+let btbTotalElem = null;
+let gameTimerElem = null;
+
+function cacheHudElements() {
+    cornerCorrectElem = document.querySelector('.corner-correct');
+    cornerTotalElem = document.querySelector('.corner-total');
+    btbCountElem = document.querySelector('.btb-count');
+    btbTotalElem = document.querySelector('.btb-total');
+    gameTimerElem = document.querySelector('.game-timer');
+}
 
 function resetGameState() {
     q_num = 0;
@@ -265,6 +281,7 @@ function resetGameState() {
     startSoonReceived = false;
     startGameReceived = false;
     selected_question_count = 0;
+    lastRenderTime = 0;
 }
 
 // ===== 割り込み追加 =====
@@ -317,7 +334,13 @@ function breakBlock() {
 }
 
 // ===== 更新 =====
-function update() {
+function update(timestamp = 0) {
+    if (timestamp - lastRenderTime < TARGET_FRAME_MS) {
+        const animId = requestAnimationFrame(update);
+        animationFrameIds.push(animId);
+        return;
+    }
+    lastRenderTime = timestamp;
     ctx.clearRect(-100, 0, 200, 1000);
 
     // 落下処理（破壊時のみ効く）
@@ -370,20 +393,15 @@ function update() {
     }
 
     // 右下の正解数/総問題数も毎フレーム更新
-    const correctElem = document.querySelector('.corner-correct');
-    const totalElem = document.querySelector('.corner-total');
-    if (correctElem) correctElem.textContent = number_of_questions - blocks.length;
-    if (totalElem) totalElem.textContent = number_of_questions;
-    const btbElem = document.querySelector('.btb-count');
-    if (btbElem) btbElem.textContent = btb_count;
-    const btbTotalElem = document.querySelector('.btb-total');
+    if (cornerCorrectElem) cornerCorrectElem.textContent = number_of_questions - blocks.length;
+    if (cornerTotalElem) cornerTotalElem.textContent = number_of_questions;
+    if (btbCountElem) btbCountElem.textContent = btb_count;
     if (btbTotalElem) btbTotalElem.textContent = btb_total;
 
     // ゲームプレイ時間の更新
     elapsed_time = (Date.now() - game_start_time) / 1000;
-    const timerElem = document.querySelector('.game-timer');
-    if (timerElem) {
-        timerElem.textContent = elapsed_time.toFixed(2);
+    if (gameTimerElem) {
+        gameTimerElem.textContent = elapsed_time.toFixed(2);
     }
 
     b_ctx.clearRect(0, 0, 1000, 50);

--- a/src/Multiplay.js
+++ b/src/Multiplay.js
@@ -53,6 +53,7 @@ function StartGame() {
     ws.onmessage = onMessage;
 
     document.querySelector(".Playing").style.display = "flex";
+    cacheHudElements();
     number_of_questions = end_num - start_num + 1;
     // 該当範囲をコピー
     question_list = eitango.slice(start_num - 1, end_num);
@@ -148,6 +149,21 @@ let startGameReceived = false;
 let currentQuestionHadMistake = false;
 let finish = false;
 let finishTimeOut;
+let lastRenderTime = 0;
+const TARGET_FRAME_MS = 1000 / 30;
+let cornerCorrectElem = null;
+let cornerTotalElem = null;
+let btbCountElem = null;
+let btbTotalElem = null;
+let gameTimerElem = null;
+
+function cacheHudElements() {
+    cornerCorrectElem = document.querySelector('.corner-correct');
+    cornerTotalElem = document.querySelector('.corner-total');
+    btbCountElem = document.querySelector('.btb-count');
+    btbTotalElem = document.querySelector('.btb-total');
+    gameTimerElem = document.querySelector('.game-timer');
+}
 
 function resetGameState() {
     q_num = 0;
@@ -173,6 +189,7 @@ function resetGameState() {
     ranking = [];
     intervalIds = [];
     animationFrameIds = [];
+    lastRenderTime = 0;
 }
 
 // ===== 割り込み追加 =====
@@ -225,7 +242,13 @@ function breakBlock() {
 }
 
 // ===== 更新 =====
-function update() {
+function update(timestamp = 0) {
+    if (timestamp - lastRenderTime < TARGET_FRAME_MS) {
+        const animationFrameId = requestAnimationFrame(update);
+        animationFrameIds.push(animationFrameId);
+        return;
+    }
+    lastRenderTime = timestamp;
     ctx.clearRect(-100, 0, 200, 1000);
 
     // 落下処理（破壊時のみ効く）
@@ -278,20 +301,15 @@ function update() {
     }
 
     // 右下の正解数/総問題数も毎フレーム更新
-    const correctElem = document.querySelector('.corner-correct');
-    const totalElem = document.querySelector('.corner-total');
-    if (correctElem) correctElem.textContent = number_of_questions - blocks.length;
-    if (totalElem) totalElem.textContent = number_of_questions;
-    const btbElem = document.querySelector('.btb-count');
-    if (btbElem) btbElem.textContent = btb_count;
-    const btbTotalElem = document.querySelector('.btb-total');
+    if (cornerCorrectElem) cornerCorrectElem.textContent = number_of_questions - blocks.length;
+    if (cornerTotalElem) cornerTotalElem.textContent = number_of_questions;
+    if (btbCountElem) btbCountElem.textContent = btb_count;
     if (btbTotalElem) btbTotalElem.textContent = btb_total;
 
     // ゲームプレイ時間の更新
     elapsed_time = (Date.now() - game_start_time) / 1000;
-    const timerElem = document.querySelector('.game-timer');
-    if (timerElem) {
-        timerElem.textContent = elapsed_time.toFixed(2);
+    if (gameTimerElem) {
+        gameTimerElem.textContent = elapsed_time.toFixed(2);
     }
 
     b_ctx.clearRect(0, 0, 1000, 50);


### PR DESCRIPTION
### Motivation
- Reduce CPU/GPU load from canvas by avoiding unnecessary per-frame draws and DOM queries in both single-player and multiplayer gameplay loops.

### Description
- Throttled the main canvas update loops in `src/Game.js` and `src/Multiplay.js` to ~30 FPS by adding `lastRenderTime`, `TARGET_FRAME_MS`, and using the `timestamp` from `requestAnimationFrame` to skip frames when appropriate.
- Cached HUD DOM elements (`.corner-correct`, `.corner-total`, `.btb-count`, `.btb-total`, `.game-timer`) once at game start via `cacheHudElements()` and replaced repeated `querySelector` calls inside the render loop with these cached references.
- Reset `lastRenderTime` in `resetGameState()` to ensure consistent frame throttling after retries or restarts.
- Called `cacheHudElements()` when entering the Playing state in both `StartGame()` implementations so HUD refs are available during updates.

### Testing
- Ran a production build with `npm run -s build` and it completed successfully (build succeeded, existing ESLint warnings remain but are unchanged).
- Attempted `npm run -s lint` but the lint script was not available/failed in this environment, so no new lint validation was added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1622a13394832893c074c317cb5a10)