### PR TITLE
Use Web Audio API for sound effects

### DIFF
--- a/src/Game.js
+++ b/src/Game.js
@@ -6,6 +6,7 @@ import { WebHaptics, defaultPatterns } from "https://cdn.skypack.dev/web-haptics
 import { useState, useEffect } from "react";
 import { getCorrectCounts, getWrongCounts, incrementCorrectCount, incrementWrongCount } from "./wrongCountStorage";
 import { getHapticsEnabled, getSpeechEnabled, getVolumeLevel } from "./settingsStorage";
+import { playSound } from "./audioPlayer";
 
 const slideVariants = {
     initial: { x: "100%", opacity: 0 },
@@ -309,9 +310,7 @@ function breakBlock() {
     // break.mp3を再生
     const volume = getVolumeLevel();
     if (volume > 0) {
-        const audio = new Audio(`${process.env.PUBLIC_URL}/break.mp3`);
-        audio.volume = volume;
-        audio.play();
+        playSound("break.mp3", volume).catch(() => {});
     }
 
     if (blocks.length === 0) return;
@@ -413,9 +412,7 @@ function update(timestamp = 0) {
         if (!beeped) {
             const volume = getVolumeLevel();
             if (volume > 0) {
-                const audio = new Audio(`${process.env.PUBLIC_URL}/beep.mp3`);
-                audio.volume = volume;
-                audio.play();
+                playSound("beep.mp3", volume).catch(() => {});
             }
             // 失敗時、カウント中のbtb_countを累計に加算
             btb_total += btb_count;
@@ -665,9 +662,7 @@ function Game() {
                     number_of_questions += 2;
                     const volume = getVolumeLevel();
                     if (volume > 0) {
-                        const audio = new Audio(`${process.env.PUBLIC_URL}/wrong.mp3`);
-                        audio.volume = volume;
-                        audio.play();
+                        playSound("wrong.mp3", volume).catch(() => {});
                     }
                 }
             });

--- a/src/Multiplay.js
+++ b/src/Multiplay.js
@@ -6,6 +6,7 @@ import { WebHaptics, defaultPatterns } from "https://cdn.skypack.dev/web-haptics
 import { useEffect, useState } from "react";
 import { incrementCorrectCount, incrementWrongCount } from "./wrongCountStorage";
 import { getHapticsEnabled, getSpeechEnabled, getVolumeLevel } from "./settingsStorage";
+import { playSound } from "./audioPlayer";
 import { feFuncA } from "framer-motion/client";
 
 const slideVariants = {
@@ -217,9 +218,7 @@ function breakBlock() {
     // break.mp3を再生
     const volume = getVolumeLevel();
     if (volume > 0) {
-        const audio = new Audio(`${process.env.PUBLIC_URL}/break.mp3`);
-        audio.volume = volume;
-        audio.play();
+        playSound("break.mp3", volume).catch(() => {});
     }
 
     if (blocks.length === 0) return;
@@ -323,9 +322,7 @@ function update(timestamp = 0) {
             sendMessage({ type: "btb", count: btb_count, user_name: localStorage.getItem("user_name"), enemy });
             const volume = getVolumeLevel();
             if (volume > 0) {
-                const audio = new Audio(`${process.env.PUBLIC_URL}/beep.mp3`);
-                audio.volume = volume;
-                audio.play().catch(e => { /* 失敗しても無視 */ });
+                playSound("beep.mp3", volume).catch(() => {});
             }
             // 失敗時、カウント中のbtb_countを累計に加算
             btb_total += btb_count;
@@ -375,9 +372,7 @@ function onMessage(event) {
             setTimeout(() => {
                 const volume = getVolumeLevel();
                 if (volume > 0) {
-                    const audio = new Audio(`${process.env.PUBLIC_URL}/damage.mp3`);
-                    audio.volume = volume;
-                    audio.play().catch(e => { /* 失敗しても無視 */ });
+                    playSound("damage.mp3", volume).catch(() => {});
                 }
             }, 1200);
             for (var i = 0; i < data.count; i++) {
@@ -574,9 +569,7 @@ function MultiPlay() {
                     }
                     const volume = getVolumeLevel();
                     if (volume > 0) {
-                        const audio = new Audio(`${process.env.PUBLIC_URL}/wrong.mp3`);
-                        audio.volume = volume;
-                        audio.play();
+                        playSound("wrong.mp3", volume).catch(() => {});
                     }
                     number_of_questions += 2;
                 }

--- a/src/audioPlayer.js
+++ b/src/audioPlayer.js
@@ -1,0 +1,54 @@
+let audioContext;
+const audioBufferCache = new Map();
+
+function getAudioContext() {
+    if (!audioContext) {
+        const AudioContextClass = window.AudioContext || window.webkitAudioContext;
+        if (!AudioContextClass) return null;
+        audioContext = new AudioContextClass();
+    }
+    return audioContext;
+}
+
+async function loadAudioBuffer(url) {
+    if (!audioBufferCache.has(url)) {
+        const bufferPromise = fetch(url)
+            .then(response => {
+                if (!response.ok) {
+                    throw new Error(`Failed to load audio: ${url}`);
+                }
+                return response.arrayBuffer();
+            })
+            .then(arrayBuffer => {
+                const context = getAudioContext();
+                if (!context) return null;
+                return context.decodeAudioData(arrayBuffer);
+            });
+        audioBufferCache.set(url, bufferPromise);
+    }
+
+    return audioBufferCache.get(url);
+}
+
+export async function playSound(fileName, volume) {
+    if (volume <= 0 || typeof window === "undefined") return;
+
+    const context = getAudioContext();
+    if (!context) return;
+
+    if (context.state === "suspended") {
+        await context.resume();
+    }
+
+    const url = `${process.env.PUBLIC_URL}/${fileName}`;
+    const audioBuffer = await loadAudioBuffer(url);
+    if (!audioBuffer) return;
+
+    const source = context.createBufferSource();
+    const gainNode = context.createGain();
+    gainNode.gain.value = volume;
+    source.buffer = audioBuffer;
+    source.connect(gainNode);
+    gainNode.connect(context.destination);
+    source.start(0);
+}


### PR DESCRIPTION
### Motivation
- Replace multiple `new Audio()` usages with a single Web Audio API helper to improve playback reliability, enable buffer caching, and provide consistent volume control.

### Description
- Added `src/audioPlayer.js` which exposes `playSound(fileName, volume)` and manages a shared `AudioContext`, buffer loading/decoding, and a `GainNode` for volume.
- Replaced HTMLAudioElement playback in `src/Game.js` and `src/Multiplay.js` for `break.mp3`, `beep.mp3`, `wrong.mp3`, and `damage.mp3` with `playSound(...)` calls and imported the helper.
- Preserved existing behavior by checking `getVolumeLevel()` before playing and by ignoring playback when volume is zero.

### Testing
- Ran `npm install` which completed successfully.
- Ran `npm run build` which succeeded and produced a build (there are existing ESLint warnings reported but the build completed).
- Ran `npm test -- --watchAll=false` which failed due to Jest being unable to resolve `react-router-dom` from `src/App.js`, an environment/Jest resolution issue not caused by the audio changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a3059b73483288db8d8db8deb371c)